### PR TITLE
Server should return an offset timestamp (or vector clock point, or…) as part of each response

### DIFF
--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -5,11 +5,14 @@ import pkg_resources
 #: Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version
 
+import six
+
 from pyramid.config import Configurator
 from pyramid.events import NewRequest
 from pyramid_multiauth import MultiAuthenticationPolicy
 
 from readinglist import authentication
+from readinglist.resource import TimeStamp
 
 
 API_VERSION = 'v%s' % __version__.split('.')[0]
@@ -44,5 +47,13 @@ def main(global_config, **settings):
             event.request.scheme = http_scheme
 
     config.add_subscriber(attach_objects_to_request, NewRequest)
+
+    # Timestamp in response headers
+
+    def add_timestamp_header_to_responses(event):
+        timestamp = six.text_type(TimeStamp.now())
+        event.request.response.headers['Timestamp'] = timestamp
+
+    config.add_subscriber(add_timestamp_header_to_responses, NewRequest)
 
     return config.make_wsgi_app()

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -14,7 +14,7 @@ def exists_or_404():
             try:
                 return view(self, *args, **kwargs)
             except RecordNotFoundError as e:
-                self.request.errors.add('path', 'id', str(e))
+                self.request.errors.add('path', 'id', six.text_type(e))
                 self.request.errors.status = "404 Resource Not Found"
         return wrapped_view
     return wrap

--- a/readinglist/tests/test_views_hello.py
+++ b/readinglist/tests/test_views_hello.py
@@ -19,3 +19,7 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
     def test_returns_none_if_eos_empty_in_settings(self):
         response = self.app.get('/')
         self.assertEqual(response.json['eos'], None)
+
+    def test_a_timestamp_header_is_provided_in_responses(self):
+        response = self.app.get('/')
+        self.assertIsNotNone(response.headers.get('Timestamp'))


### PR DESCRIPTION
Clients will want to fetch all changes that have occurred since their last query. They can do so by specifying a timestamp. The server should hand them that each time it returns a response.