### PR TITLE
Finer grained permissions in resource

### DIFF
--- a/readinglist/authentication.py
+++ b/readinglist/authentication.py
@@ -67,7 +67,12 @@ class AuthorizationPolicy(object):
         """Currently we don't check scopes nor permissions.
         Authenticated users only are allowed.
         """
-        return Authenticated in principals
+        PERMISSIONS = {
+            'readonly': Authenticated,
+            'readwrite': Authenticated,
+        }
+        role = PERMISSIONS.get(permission)
+        return role and role in principals
 
     def principals_allowed_by_permission(self, context, permission):
         raise NotImplementedError()  # PRAGMA NOCOVER

--- a/readinglist/authentication.py
+++ b/readinglist/authentication.py
@@ -1,10 +1,10 @@
 from zope.interface import implementer
 from pyramid import authentication as base_auth
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
+from pyramid.security import Authenticated
 from pyramid.httpexceptions import HTTPServiceUnavailable
 from fxa.oauth import Client as OAuthClient
 from fxa import errors as fxa_errors
-from pyramid.security import Authenticated
 
 
 def check_credentials(username, password, request):
@@ -64,12 +64,10 @@ class Oauth2AuthenticationPolicy(base_auth.CallbackAuthenticationPolicy):
 @implementer(IAuthorizationPolicy)
 class AuthorizationPolicy(object):
     def permits(self, context, principals, permission):
-        PERMISSIONS = {
-            'articles': Authenticated,
-        }
-        if permission in PERMISSIONS:
-            return PERMISSIONS[permission] in principals
-        return False
+        """Currently we don't check scopes nor permissions.
+        Authenticated users only are allowed.
+        """
+        return Authenticated in principals
 
     def principals_allowed_by_permission(self, context, permission):
         raise NotImplementedError()  # PRAGMA NOCOVER

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -3,6 +3,7 @@ import json
 
 import six
 import colander
+from cornice.resource import view
 
 from readinglist.backend.exceptions import RecordNotFoundError
 
@@ -87,6 +88,7 @@ class BaseResource(object):
     # End-points
     #
 
+    @view(permission='readonly')
     def collection_get(self):
         records = self.db.get_all(**self.db_kwargs)
         meta = {
@@ -98,6 +100,7 @@ class BaseResource(object):
         }
         return body
 
+    @view(permission='readwrite')
     @validates_or_400()
     def collection_post(self):
         new_record = self.deserialize(self.request.body)
@@ -105,12 +108,14 @@ class BaseResource(object):
         self.record = self.db.create(record=new_record, **self.db_kwargs)
         return self.record
 
+    @view(permission='readonly')
     @exists_or_404()
     def get(self):
         record_id = self.request.matchdict['id']
         self.record = self.db.get(record_id=record_id, **self.db_kwargs)
         return self.record
 
+    @view(permission='readwrite')
     @exists_or_404()
     @validates_or_400()
     def put(self):
@@ -122,6 +127,7 @@ class BaseResource(object):
                                      **self.db_kwargs)
         return self.record
 
+    @view(permission='readwrite')
     @exists_or_404()
     @validates_or_400()
     def patch(self):
@@ -139,6 +145,7 @@ class BaseResource(object):
                                 **self.db_kwargs)
         return record
 
+    @view(permission='readwrite')
     @exists_or_404()
     def delete(self):
         record_id = self.request.matchdict['id']

--- a/readinglist/views/article.py
+++ b/readinglist/views/article.py
@@ -46,8 +46,7 @@ class ArticleSchema(RessourceSchema):
 
 @resource(collection_path='/articles',
           path='/articles/{id}',
-          description='Collection of articles',
-          permission='articles')
+          description='Collection of articles')
 class Article(BaseResource):
     mapping = ArticleSchema()
 


### PR DESCRIPTION
As suggested by @Natim and @ametaireau, just ignore
permissions in AuthorizationPolicy so far.

Once we have FxA scopes for readinglist, we will want
to perform authorization based on token scopes (``readinglist:read``, ``readinglist:write``)...