### PR TITLE
Refactor of resource decorator

### DIFF
--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -114,7 +114,8 @@ class BaseResourceViewsTest(BaseWebTest):
                              '',
                              headers=self.headers,
                              status=400)
-        self.assertEqual(resp.json['errors'][0]['description'], 'Required')
+        self.assertEqual(resp.json['errors'][0]['description'],
+                         'url is missing')
 
     def test_invalid_uft8_raises_error(self):
         resp = self.app.post(self.collection_url,
@@ -209,11 +210,12 @@ class BaseResourceViewsTest(BaseWebTest):
 
 class BaseResourceAuthorizationTest(BaseWebTest):
     def test_all_views_require_authentication(self):
+        record = self.record_factory()
         self.app.get(self.collection_url, status=401)
-        self.app.post(self.collection_url, {}, status=401)
+        self.app.post(self.collection_url, record, status=401)
         url = self.item_url.format(id='abc')
         self.app.get(url, status=401)
-        self.app.patch(url, {}, status=401)
+        self.app.patch(url, record, status=401)
         self.app.delete(url, status=401)
 
     @mock.patch('readinglist.authentication.AuthorizationPolicy.permits')
@@ -231,7 +233,7 @@ class BaseResourceAuthorizationTest(BaseWebTest):
         self.app.get(url)
         self.assertEqual(permission_required(), 'readonly')
 
-        self.app.patch(url, {})
+        self.app.patch_json(url, {})
         self.assertEqual(permission_required(), 'readwrite')
 
         self.app.delete(url)

--- a/readinglist/views/article.py
+++ b/readinglist/views/article.py
@@ -1,9 +1,7 @@
-from cornice.resource import resource
-
 import colander
 from colander import SchemaNode, String, null
 
-from readinglist.resource import BaseResource, RessourceSchema, TimeStamp
+from readinglist.resource import crud, BaseResource, RessourceSchema, TimeStamp
 
 
 # removes whitespace, newlines, and tabs from the beginning/end of a string
@@ -38,30 +36,28 @@ class ArticleSchema(RessourceSchema):
     excerpt = SchemaNode(String(), missing="")
 
     marked_read_by = DeviceName(missing=None)
-    marked_read_on = TimeStamp(missing=None)
+    marked_read_on = TimeStamp(auto_now=False)
     word_count = SchemaNode(colander.Integer(), missing=None)
     resolved_url = SchemaNode(String(), missing=None)
     resolved_title = SchemaNode(String(), missing=None)
 
 
-@resource(collection_path='/articles',
-          path='/articles/{id}',
-          description='Collection of articles')
+@crud()
 class Article(BaseResource):
     mapping = ArticleSchema()
 
-    def validate(self, record):
+    def process_record(self, new, old=None):
         """Currently, article content is not fetched, thus resolved url
         and title are the ones provided.
         """
-        validated = super(Article, self).validate(record)
+        record = super(Article, self).process_record(new, old)
 
-        validated['resolved_title'] = validated['title']
-        validated['resolved_url'] = validated['url']
+        record['resolved_title'] = record['title']
+        record['resolved_url'] = record['url']
 
-        if validated['unread']:
+        if record['unread']:
             # Article is not read
-            validated['marked_read_on'] = None
-            validated['marked_read_by'] = None
+            record['marked_read_on'] = None
+            record['marked_read_by'] = None
 
-        return validated
+        return record


### PR DESCRIPTION
Two things still to consider:

* I could not remove as much as I wanted because of patched records validation
* I had to sneak into Cornice view/resource decorators in order to apply schema on certain views, and not all.

The overall result is not very sexy comparing to previous code, but I believe it could go in the right direction if Cornice would expose some little things publicly like https://github.com/mozilla-services/cornice/blob/master/cornice/schemas.py#L94