### PR TITLE
Switch to vector-clock timestamps (fixes #4)

### DIFF
--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -10,7 +10,6 @@ from pyramid.httpexceptions import HTTPTemporaryRedirect
 from pyramid_multiauth import MultiAuthenticationPolicy
 
 from readinglist import authentication
-from readinglist.resource import TimeStamp
 
 
 # Module version, as defined in PEP-0396.
@@ -61,6 +60,10 @@ def attach_http_objects(config):
     def on_new_request(event):
         # Attach objects on requests for easier access.
         event.request.db = config.registry.backend
+
+        # Track incoming request timestamp
+        event.request.timestamp = config.registry.backend.now()
+
         http_scheme = config.registry.settings.get('readinglist.http_scheme')
         if http_scheme:
             event.request.scheme = http_scheme
@@ -68,8 +71,8 @@ def attach_http_objects(config):
     config.add_subscriber(on_new_request, NewRequest)
 
     def on_new_response(event):
-        # Add timestamp info in response headers.
-        timestamp = six.text_type(TimeStamp.now())
+        # Add request timestamp info in response headers.
+        timestamp = six.text_type(event.request.timestamp)
         event.request.response.headers['Timestamp'] = timestamp.encode('utf-8')
 
         # Add backoff in response headers

--- a/readinglist/backend/__init__.py
+++ b/readinglist/backend/__init__.py
@@ -13,6 +13,9 @@ class BackendBase(object):
     def ping(self):
         raise NotImplementedError
 
+    def now(self):
+        raise NotImplementedError
+
     def create(self, resource, user_id, record):
         raise NotImplementedError
 

--- a/readinglist/backend/__init__.py
+++ b/readinglist/backend/__init__.py
@@ -13,7 +13,7 @@ class BackendBase(object):
     def ping(self):
         raise NotImplementedError
 
-    def now(self):
+    def revision(self, user_id):
         raise NotImplementedError
 
     def create(self, resource, user_id, record):

--- a/readinglist/backend/memory.py
+++ b/readinglist/backend/memory.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from readinglist.backend import BackendBase, exceptions
 from readinglist.utils import COMPARISON
+from readinglist.utils import timestamper
 
 
 tree = lambda: defaultdict(tree)
@@ -20,6 +21,9 @@ class Memory(BackendBase):
 
     def ping(self):
         return True
+
+    def now(self):
+        return timestamper.now()
 
     def create(self, resource, user_id, record):
         resource_name = classname(resource)

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -1,4 +1,3 @@
-import time
 import re
 import inspect
 
@@ -8,7 +7,7 @@ from cornice import resource
 
 from readinglist.backend.exceptions import RecordNotFoundError
 from readinglist.errors import json_error, ImmutableFieldError
-from readinglist.utils import COMPARISON, native_value
+from readinglist.utils import COMPARISON, native_value, timestamper
 
 
 def exists_or_404():
@@ -53,13 +52,9 @@ class TimeStamp(colander.SchemaNode):
     auto_now = True
     missing = None
 
-    @staticmethod
-    def now():
-        return int(time.time())
-
     def deserialize(self, cstruct=colander.null):
         if cstruct is colander.null and self.auto_now:
-            cstruct = TimeStamp.now()
+            cstruct = timestamper.now()
         return super(TimeStamp, self).deserialize(cstruct)
 
 
@@ -124,6 +119,7 @@ class BaseResource(object):
         """Hook to post-process records and introduce specific logics
         or validation.
         """
+        new[self.modified_field] = self.request.timestamp
         new = self.preprocess_record(new, old)
         return new
 
@@ -214,7 +210,6 @@ class BaseResource(object):
 
         updated = self.record.copy()
         updated.update(**changes)
-        updated[self.modified_field] = TimeStamp.now()
         return self.validate(updated)
 
     #

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -7,7 +7,7 @@ from cornice import resource
 
 from readinglist.backend.exceptions import RecordNotFoundError
 from readinglist.errors import json_error, ImmutableFieldError
-from readinglist.utils import COMPARISON, native_value, timestamper
+from readinglist.utils import COMPARISON, native_value, time_second
 
 
 def exists_or_404():
@@ -43,6 +43,19 @@ def validates_or_400():
     return wrap
 
 
+def refresh_revision():
+    """View decorator to refresh the request revision, because it was
+    incremented during the view execution."""
+    def wrap(view):
+        def wrapped_view(self, *args, **kwargs):
+            result = view(self, *args, **kwargs)
+            user_id = self.request.authenticated_userid
+            self.request.revision = self.db.revision(user_id)
+            return result
+        return wrapped_view
+    return wrap
+
+
 class TimeStamp(colander.SchemaNode):
     """Basic integer field that takes current timestamp if no value
     is provided.
@@ -54,7 +67,7 @@ class TimeStamp(colander.SchemaNode):
 
     def deserialize(self, cstruct=colander.null):
         if cstruct is colander.null and self.auto_now:
-            cstruct = timestamper.now()
+            cstruct = time_second()
         return super(TimeStamp, self).deserialize(cstruct)
 
 
@@ -119,7 +132,6 @@ class BaseResource(object):
         """Hook to post-process records and introduce specific logics
         or validation.
         """
-        new[self.modified_field] = self.request.timestamp
         new = self.preprocess_record(new, old)
         return new
 
@@ -233,6 +245,7 @@ class BaseResource(object):
         return body
 
     @resource.view(permission='readwrite', with_schema=True)
+    @refresh_revision()
     def collection_post(self):
         new_record = self.process_record(self.request.validated)
         self.record = self.db.create(record=new_record, **self.db_kwargs)
@@ -247,6 +260,7 @@ class BaseResource(object):
         return self.record
 
     @resource.view(permission='readwrite', with_schema=True)
+    @refresh_revision()
     def put(self):
         record_id = self.request.matchdict['id']
 
@@ -265,6 +279,7 @@ class BaseResource(object):
     @resource.view(permission='readwrite')
     @exists_or_404()
     @validates_or_400()
+    @refresh_revision()
     def patch(self):
         record_id = self.request.matchdict['id']
         self.record = self.db.get(record_id=record_id, **self.db_kwargs)
@@ -280,6 +295,7 @@ class BaseResource(object):
 
     @resource.view(permission='readwrite')
     @exists_or_404()
+    @refresh_revision()
     def delete(self):
         record_id = self.request.matchdict['id']
         self.record = self.db.delete(record_id=record_id, **self.db_kwargs)

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -163,7 +163,7 @@ class BaseResource(object):
                     return
 
                 filters.append(
-                    (self.modified_field, value, COMPARISON.MIN)
+                    (self.modified_field, value, COMPARISON.GT)
                 )
                 continue
 

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -195,7 +195,7 @@ class BaseResourceViewsTest(BaseWebTest):
         self.assertEquals(resp.json['_id'], stored['_id'])
         self.assertRecordNotEquals(resp.json, stored)
 
-    @mock.patch('readinglist.resource.TimeStamp.now')
+    @mock.patch('readinglist.utils.TimeStamper.now')
     def test_modify_record_updates_timestamp(self, now_mocked):
         now_mocked.return_value = 42
 
@@ -237,6 +237,8 @@ class BaseResourceViewsTest(BaseWebTest):
     def test_replace_record(self):
         url = self.item_url.format(id=self.record['_id'])
         before = self.db.get(self.resource, u'bob', self.record['_id'])
+        # Decimal type is not JSON serializable, convert before posting
+        before['last_modified'] = float(before['last_modified'])
 
         modified = self.modify_record(self.record)
         replaced = before.copy()

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -195,15 +195,12 @@ class BaseResourceViewsTest(BaseWebTest):
         self.assertEquals(resp.json['_id'], stored['_id'])
         self.assertRecordNotEquals(resp.json, stored)
 
-    @mock.patch('readinglist.utils.TimeStamper.now')
-    def test_modify_record_updates_timestamp(self, now_mocked):
-        now_mocked.return_value = 42
-
-        url = self.item_url.format(id=self.record['_id'])
+    def test_modify_record_updates_timestamp(self):
         stored = self.db.get(self.resource, u'bob', self.record['_id'])
         before = stored['last_modified']
-        modified = self.modify_record(self.record)
 
+        url = self.item_url.format(id=self.record['_id'])
+        modified = self.modify_record(self.record)
         resp = self.app.patch_json(url, modified, headers=self.headers)
         after = resp.json['last_modified']
         self.assertNotEquals(after, before)

--- a/readinglist/tests/test_backend.py
+++ b/readinglist/tests/test_backend.py
@@ -21,6 +21,7 @@ class BackendBaseTest(unittest.TestCase):
         calls = [
             (self.backend.flush,),
             (self.backend.ping,),
+            (self.backend.now,),
             (self.backend.create, '', '', {}),
             (self.backend.get, '', '', ''),
             (self.backend.update, '', '', '', {}),

--- a/readinglist/tests/test_backend.py
+++ b/readinglist/tests/test_backend.py
@@ -21,7 +21,7 @@ class BackendBaseTest(unittest.TestCase):
         calls = [
             (self.backend.flush,),
             (self.backend.ping,),
-            (self.backend.now,),
+            (self.backend.revision, ''),
             (self.backend.create, '', '', {}),
             (self.backend.get, '', '', ''),
             (self.backend.update, '', '', '', {}),

--- a/readinglist/tests/test_schemas.py
+++ b/readinglist/tests/test_schemas.py
@@ -8,9 +8,9 @@ from .support import unittest
 
 
 class TimeStampTest(unittest.TestCase):
-    @mock.patch('readinglist.utils.TimeStamper.now')
-    def test_default_value_comes_from_timestamper(self, now_mocked):
-        now_mocked.return_value = 666
+    @mock.patch('readinglist.resource.time_second')
+    def test_default_value_comes_from_timestamper(self, time_mocked):
+        time_mocked.return_value = 666
         default = TimeStamp().deserialize(colander.null)
         self.assertEqual(default, 666)
 

--- a/readinglist/tests/test_schemas.py
+++ b/readinglist/tests/test_schemas.py
@@ -1,8 +1,18 @@
+import mock
 import colander
 
+from readinglist.resource import TimeStamp
 from readinglist.views.article import ArticleSchema
 
 from .support import unittest
+
+
+class TimeStampTest(unittest.TestCase):
+    @mock.patch('readinglist.utils.TimeStamper.now')
+    def test_default_value_comes_from_timestamper(self, now_mocked):
+        now_mocked.return_value = 666
+        default = TimeStamp().deserialize(colander.null)
+        self.assertEqual(default, 666)
 
 
 class ArticleSchemaTest(unittest.TestCase):

--- a/readinglist/tests/test_utils.py
+++ b/readinglist/tests/test_utils.py
@@ -1,3 +1,5 @@
+import threading
+
 import colander
 
 from readinglist.utils import native_value, strip_whitespace
@@ -36,3 +38,45 @@ class StripWhitespaceTest(unittest.TestCase):
 
     def test_idempotent_for_null_values(self):
         self.assertEqual(strip_whitespace(colander.null), colander.null)
+
+
+class TimeStamperTest(unittest.TestCase):
+    def test_timestamps_are_based_on_real_time(self):
+        msec_before = msec_time()
+        now = timestamper.now()
+        msec_after = msec_time()
+        self.assertTrue(msec_before - 1 < now < msec_after + 1)
+
+    def test_timestamp_are_always_different(self):
+        before = timestamper.now()
+        now = timestamper.now()
+        after = timestamper.now()
+        self.assertTrue(before < now < after)
+
+    def test_timestamp_have_under_one_millisecond_precision(self):
+        msec_before = msec_time()
+        now1 = timestamper.now()
+        now2 = timestamper.now()
+        msec_after = msec_time()
+        self.assertNotEqual(now1, now2)
+        # Assert than less than 1 msec elapsed (Can fail on very slow machine)
+        self.assertTrue(msec_before - msec_after <= 1)
+
+    def test_timestamp_are_thread_safe(self):
+        obtained = []
+
+        def hit_timestamp():
+            for i in range(1000):
+                obtained.append(timestamper.now())
+
+        thread1 = threading.Thread(target=hit_timestamp)
+        thread2 = threading.Thread(target=hit_timestamp)
+        thread1.start()
+        thread2.start()
+        thread1.join()
+        thread2.join()
+
+        # With CPython (GIL), list appending is thread-safe
+        self.assertEqual(len(obtained), 2000)
+        # No duplicated timestamps
+        self.assertEqual(len(set(obtained)), len(obtained))

--- a/readinglist/tests/test_utils.py
+++ b/readinglist/tests/test_utils.py
@@ -1,5 +1,3 @@
-import threading
-
 import colander
 
 from readinglist.utils import native_value, strip_whitespace
@@ -38,45 +36,3 @@ class StripWhitespaceTest(unittest.TestCase):
 
     def test_idempotent_for_null_values(self):
         self.assertEqual(strip_whitespace(colander.null), colander.null)
-
-
-class TimeStamperTest(unittest.TestCase):
-    def test_timestamps_are_based_on_real_time(self):
-        msec_before = msec_time()
-        now = timestamper.now()
-        msec_after = msec_time()
-        self.assertTrue(msec_before - 1 < now < msec_after + 1)
-
-    def test_timestamp_are_always_different(self):
-        before = timestamper.now()
-        now = timestamper.now()
-        after = timestamper.now()
-        self.assertTrue(before < now < after)
-
-    def test_timestamp_have_under_one_millisecond_precision(self):
-        msec_before = msec_time()
-        now1 = timestamper.now()
-        now2 = timestamper.now()
-        msec_after = msec_time()
-        self.assertNotEqual(now1, now2)
-        # Assert than less than 1 msec elapsed (Can fail on very slow machine)
-        self.assertTrue(msec_before - msec_after <= 1)
-
-    def test_timestamp_are_thread_safe(self):
-        obtained = []
-
-        def hit_timestamp():
-            for i in range(1000):
-                obtained.append(timestamper.now())
-
-        thread1 = threading.Thread(target=hit_timestamp)
-        thread2 = threading.Thread(target=hit_timestamp)
-        thread1.start()
-        thread2.start()
-        thread1.join()
-        thread2.join()
-
-        # With CPython (GIL), list appending is thread-safe
-        self.assertEqual(len(obtained), 2000)
-        # No duplicated timestamps
-        self.assertEqual(len(set(obtained)), len(obtained))

--- a/readinglist/tests/test_views_article.py
+++ b/readinglist/tests/test_views_article.py
@@ -177,8 +177,8 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
         article = MINIMALIST_ARTICLE.copy()
         resp = self.app.post_json('/articles', article, headers=self.headers)
 
-        current = float(resp.headers['Timestamp'])
-        url = '/articles?_since={0:.3f}'.format(current)
+        current = int(resp.headers['Timestamp'])
+        url = '/articles?_since={0}'.format(current)
 
         resp = self.app.get(url, headers=self.headers)
         self.assertEqual(len(resp.json['items']), 0)

--- a/readinglist/tests/test_views_article.py
+++ b/readinglist/tests/test_views_article.py
@@ -1,9 +1,10 @@
+import time
+import threading
 import mock
 from random import shuffle
 
 from readinglist.errors import ERRORS
 from readinglist.views.article import Article
-from readinglist.utils import timestamper
 
 from .support import BaseResourceTest, BaseWebTest, unittest
 
@@ -136,17 +137,17 @@ class ArticleFilteringTest(BaseWebTest, unittest.TestCase):
 
 class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
 
-    @mock.patch('readinglist.utils.TimeStamper.now')
-    def setUp(self, now_mocked):
+    @mock.patch('readinglist.backend.BackendBase.revision')
+    def setUp(self, revision_mocked):
         super(ArticleFilterModifiedTest, self).setUp()
         for i in range(6):
-            now_mocked.return_value = i
+            revision_mocked.return_value = i
             article = MINIMALIST_ARTICLE.copy()
             self.app.post_json('/articles', article, headers=self.headers)
 
     def test_filter_with_since_is_exclusive(self):
         resp = self.app.get('/articles?_since=3', headers=self.headers)
-        self.assertEqual(len(resp.json['items']), 2)
+        self.assertEqual(len(resp.json['items']), 3)
 
     def test_the_timestamp_header_is_equal_to_last_modification(self):
         article = MINIMALIST_ARTICLE.copy()
@@ -155,11 +156,10 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
         header = float(resp.headers['Timestamp'])
         self.assertEqual(header, modification)
 
-    def test_filter_with_since_accepts_decimal_value(self):
-        before = timestamper.now()
+    def test_filter_with_since_accepts_numeric_value(self):
         article = MINIMALIST_ARTICLE.copy()
         self.app.post_json('/articles', article, headers=self.headers)
-        url = '/articles?_since={0}'.format(before)
+        url = '/articles?_since=6'
         resp = self.app.get(url, headers=self.headers)
         self.assertEqual(len(resp.json['items']), 1)
 
@@ -196,6 +196,77 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
     def test_filter_with_since_rejects_decimal_value(self):
         url = '/articles?_since=1.2'
         self.app.get(url, headers=self.headers, status=400)
+
+    def test_timestamp_are_always_identical_on_read(self):
+
+        def read_timestamp():
+            resp = self.app.head('/articles', headers=self.headers)
+            return int(resp.headers['Timestamp'])
+
+        before = read_timestamp()
+        now = read_timestamp()
+        after = read_timestamp()
+        self.assertTrue(before == now == after)
+
+    def test_timestamp_are_always_incremented_on_creation(self):
+
+        def read_timestamp():
+            resp = self.app.post_json('/articles',
+                                      MINIMALIST_ARTICLE,
+                                      headers=self.headers)
+            return int(resp.json['last_modified'])
+
+        before = read_timestamp()
+        now = read_timestamp()
+        after = read_timestamp()
+        self.assertTrue(before < now < after)
+
+    def test_records_created_during_fetch_are_above_fetch_revision(self):
+
+        revisions = {}
+
+        def long_fetch():
+
+            def delayed_get(*args, **kwargs):
+                time.sleep(.25)
+                return MINIMALIST_ARTICLE
+
+            with mock.patch.object(self.db, 'get_all', delayed_get):
+                resp = self.app.head('/articles',
+                                     headers=self.headers)
+                revisions['fetch'] = resp.headers['Timestamp']
+
+        thread = threading.Thread(target=long_fetch)
+        thread.start()
+        resp = self.app.post_json('/articles',
+                                  MINIMALIST_ARTICLE,
+                                  headers=self.headers)
+        revisions['post'] = resp.headers['Timestamp']
+        thread.join()
+        self.assertTrue(revisions['post'] > revisions['fetch'])
+
+    def test_timestamps_are_thread_safe(self):
+        obtained = []
+
+        def hit_post():
+            for i in range(100):
+                resp = self.app.post_json('/articles',
+                                          MINIMALIST_ARTICLE,
+                                          headers=self.headers)
+                current = int(resp.json['last_modified'])
+                obtained.append(current)
+
+        thread1 = threading.Thread(target=hit_post)
+        thread2 = threading.Thread(target=hit_post)
+        thread1.start()
+        thread2.start()
+        thread1.join()
+        thread2.join()
+
+        # With CPython (GIL), list appending is thread-safe
+        self.assertEqual(len(obtained), 200)
+        # No duplicated revisions
+        self.assertEqual(len(set(obtained)), len(obtained))
 
 
 class ArticleSortingTest(BaseWebTest, unittest.TestCase):

--- a/readinglist/utils.py
+++ b/readinglist/utils.py
@@ -4,10 +4,17 @@ except ImportError:  # pragma: no cover
     import json  # NOQA
 
 import ast
+import decimal
+import threading
+import time
+
 from colander import null
+
 
 # removes whitespace, newlines, and tabs from the beginning/end of a string
 strip_whitespace = lambda v: v.strip(' \t\n\r') if v is not null else v
+
+msec_time = lambda: int(time.time() * 1000.0)  # floor
 
 
 def native_value(value):
@@ -34,3 +41,39 @@ COMPARISON = Enum(
     EQ='==',
     GT='>',
 )
+
+
+class TimeStamper(object):
+    """A helper to generate accurate timestamps.
+
+    It increments a fraction in case prevent two simultaneous calls to return
+    the same timestamp.
+
+    This is mainly used for in-memory backend. Ideally, this task should rely
+    on storage backend transaction capabilities to guarantee timestamp unicity
+    in a multiprocess environment.
+
+    .. note:
+
+        Original comes from http://stackoverflow.com/a/157711
+    """
+    fraction = decimal.Decimal('0.001')
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.prev = None
+        self.count = 0
+
+    def now(self):
+        with self.lock:
+            timestamp = decimal.Decimal(msec_time())
+            if timestamp == self.prev:
+                timestamp += self.count * self.fraction
+                self.count += 1
+            else:
+                self.prev = timestamp
+                self.count = 1
+            return timestamp
+
+
+timestamper = TimeStamper()

--- a/readinglist/utils.py
+++ b/readinglist/utils.py
@@ -4,8 +4,6 @@ except ImportError:  # pragma: no cover
     import json  # NOQA
 
 import ast
-import decimal
-import threading
 import time
 
 from colander import null
@@ -14,6 +12,7 @@ from colander import null
 # removes whitespace, newlines, and tabs from the beginning/end of a string
 strip_whitespace = lambda v: v.strip(' \t\n\r') if v is not null else v
 
+time_second = lambda: int(time.time())
 msec_time = lambda: int(time.time() * 1000.0)  # floor
 
 
@@ -41,39 +40,3 @@ COMPARISON = Enum(
     EQ='==',
     GT='>',
 )
-
-
-class TimeStamper(object):
-    """A helper to generate accurate timestamps.
-
-    It increments a fraction in case prevent two simultaneous calls to return
-    the same timestamp.
-
-    This is mainly used for in-memory backend. Ideally, this task should rely
-    on storage backend transaction capabilities to guarantee timestamp unicity
-    in a multiprocess environment.
-
-    .. note:
-
-        Original comes from http://stackoverflow.com/a/157711
-    """
-    fraction = decimal.Decimal('0.001')
-
-    def __init__(self):
-        self.lock = threading.Lock()
-        self.prev = None
-        self.count = 0
-
-    def now(self):
-        with self.lock:
-            timestamp = decimal.Decimal(msec_time())
-            if timestamp == self.prev:
-                timestamp += self.count * self.fraction
-                self.count += 1
-            else:
-                self.prev = timestamp
-                self.count = 1
-            return timestamp
-
-
-timestamper = TimeStamper()


### PR DESCRIPTION
Avoid races using vector-clock timestamps, as described in #4 : 

```
Client A: [        fetch                 ] t = 1234
Client B:                     [insert] t = 1230
Client A:                                           [fetch since t=1234] t=1345
```

Basically, a naive approach: 
* build millisecond timestamps with incremented fraction
* each incoming request has a different timestamp (even if less than 1msec of difference)
* ``last_modified`` is assigned with this request timestamp
* request timestamp is provided in request response

To be improved/reviewed/discussed:
* Filter ``_since`` is exclusive (strictly greater ``>``)
* ``stored_on`` is not receiving the same value as ``last_modified``
* Implementation of timestamping shall be implemented by storage backend (guarantee timestamp unicity in *multiprocess* environment)