### PR TITLE
Rework notion of revision

### DIFF
--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -61,9 +61,9 @@ def attach_http_objects(config):
         # Attach objects on requests for easier access.
         event.request.db = config.registry.backend
 
-        # Current revision when request comes in
+        # Current timestamp when request comes in
         user_id = event.request.authenticated_userid
-        event.request.revision = event.request.db.revision(user_id)
+        event.request.timestamp = event.request.db.timestamp(user_id)
 
         http_scheme = config.registry.settings.get('readinglist.http_scheme')
         if http_scheme:
@@ -72,9 +72,9 @@ def attach_http_objects(config):
     config.add_subscriber(on_new_request, NewRequest)
 
     def on_new_response(event):
-        # Add request revision info in response headers.
-        revision = six.text_type(getattr(event.request, 'revision', ''))
-        event.request.response.headers['Timestamp'] = revision.encode('utf-8')
+        # Add request timestamp info in response headers.
+        timestamp = six.text_type(getattr(event.request, 'timestamp', ''))
+        event.request.response.headers['Timestamp'] = timestamp.encode('utf-8')
 
         # Add backoff in response headers
         backoff = config.registry.settings.get("readinglist.backoff")

--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -61,10 +61,6 @@ def attach_http_objects(config):
         # Attach objects on requests for easier access.
         event.request.db = config.registry.backend
 
-        # Current timestamp when request comes in
-        user_id = event.request.authenticated_userid
-        event.request.timestamp = event.request.db.timestamp(user_id)
-
         http_scheme = config.registry.settings.get('readinglist.http_scheme')
         if http_scheme:
             event.request.scheme = http_scheme
@@ -72,10 +68,6 @@ def attach_http_objects(config):
     config.add_subscriber(on_new_request, NewRequest)
 
     def on_new_response(event):
-        # Add request timestamp info in response headers.
-        timestamp = six.text_type(getattr(event.request, 'timestamp', ''))
-        event.request.response.headers['Timestamp'] = timestamp.encode('utf-8')
-
         # Add backoff in response headers
         backoff = config.registry.settings.get("readinglist.backoff")
         if backoff is not None:

--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -2,8 +2,6 @@
 """
 import pkg_resources
 
-import six
-
 from pyramid.config import Configurator
 from pyramid.events import NewRequest, NewResponse
 from pyramid.httpexceptions import HTTPTemporaryRedirect

--- a/readinglist/backend/__init__.py
+++ b/readinglist/backend/__init__.py
@@ -13,7 +13,7 @@ class BackendBase(object):
     def ping(self):
         raise NotImplementedError
 
-    def timestamp(self, user_id):
+    def timestamp(self, resource, user_id):
         raise NotImplementedError
 
     def create(self, resource, user_id, record):

--- a/readinglist/backend/__init__.py
+++ b/readinglist/backend/__init__.py
@@ -13,7 +13,7 @@ class BackendBase(object):
     def ping(self):
         raise NotImplementedError
 
-    def revision(self, user_id):
+    def timestamp(self, user_id):
         raise NotImplementedError
 
     def create(self, resource, user_id, record):

--- a/readinglist/backend/memory.py
+++ b/readinglist/backend/memory.py
@@ -3,7 +3,7 @@ from operator import itemgetter
 from collections import defaultdict
 
 from readinglist.backend import BackendBase, exceptions
-from readinglist.utils import COMPARISON
+from readinglist import utils
 
 
 tree = lambda: defaultdict(tree)
@@ -14,7 +14,7 @@ class Memory(BackendBase):
     def __init__(self, *args, **kwargs):
         super(Memory, self).__init__(*args, **kwargs)
         self._store = tree()
-        self._timestamps = defaultdict(int)
+        self._timestamps = {}
 
     def flush(self):
         pass
@@ -23,11 +23,22 @@ class Memory(BackendBase):
         return True
 
     def timestamp(self, user_id):
-        return self._timestamps[user_id]
+        return self._timestamps.get(user_id, utils.msec_time())
 
     def _bump_timestamp(self, user_id):
-        self._timestamps[user_id] += 1
-        return self._timestamps[user_id]
+        """Timestamp are base on current millisecond.
+
+        .. note ::
+
+            Here it is assumed that requests from the same user won't burst
+            several time per millisecond.
+        """
+        previous = self._timestamps.get(user_id)
+        current = utils.msec_time()
+        if previous and previous == current:
+            current += 1
+        self._timestamps[user_id] = current
+        return current
 
     def create(self, resource, user_id, record):
         resource_name = classname(resource)
@@ -67,12 +78,12 @@ class Memory(BackendBase):
 
     def __apply_filters(self, records, filters):
         operators = {
-            COMPARISON.LT: operator.lt,
-            COMPARISON.MAX: operator.le,
-            COMPARISON.EQ: operator.eq,
-            COMPARISON.NOT: operator.ne,
-            COMPARISON.MIN: operator.ge,
-            COMPARISON.GT: operator.gt,
+            utils.COMPARISON.LT: operator.lt,
+            utils.COMPARISON.MAX: operator.le,
+            utils.COMPARISON.EQ: operator.eq,
+            utils.COMPARISON.NOT: operator.ne,
+            utils.COMPARISON.MIN: operator.ge,
+            utils.COMPARISON.GT: operator.gt,
         }
 
         for record in records:

--- a/readinglist/backend/memory.py
+++ b/readinglist/backend/memory.py
@@ -14,7 +14,7 @@ class Memory(BackendBase):
     def __init__(self, *args, **kwargs):
         super(Memory, self).__init__(*args, **kwargs)
         self._store = tree()
-        self._revisions = defaultdict(int)
+        self._timestamps = defaultdict(int)
 
     def flush(self):
         pass
@@ -22,18 +22,18 @@ class Memory(BackendBase):
     def ping(self):
         return True
 
-    def revision(self, user_id):
-        return self._revisions[user_id]
+    def timestamp(self, user_id):
+        return self._timestamps[user_id]
 
-    def _bump_revision(self, user_id):
-        self._revisions[user_id] += 1
-        return self._revisions[user_id]
+    def _bump_timestamp(self, user_id):
+        self._timestamps[user_id] += 1
+        return self._timestamps[user_id]
 
     def create(self, resource, user_id, record):
         resource_name = classname(resource)
         _id = record[resource.id_field] = self.id_generator()
-        revision = self._bump_revision(user_id)
-        record[resource.modified_field] = revision
+        timestamp = self._bump_timestamp(user_id)
+        record[resource.modified_field] = timestamp
         self._store[resource_name][user_id][_id] = record
         return record
 
@@ -46,15 +46,15 @@ class Memory(BackendBase):
 
     def update(self, resource, user_id, record_id, record):
         resource_name = classname(resource)
-        revision = self._bump_revision(user_id)
-        record[resource.modified_field] = revision
+        timestamp = self._bump_timestamp(user_id)
+        record[resource.modified_field] = timestamp
         self._store[resource_name][user_id][record_id] = record
         return record
 
     def delete(self, resource, user_id, record_id):
         resource_name = classname(resource)
         existing = self.get(resource, user_id, record_id)
-        self._bump_revision(user_id)
+        self._bump_timestamp(user_id)
         self._store[resource_name][user_id].pop(record_id)
         return existing
 

--- a/readinglist/backend/memory.py
+++ b/readinglist/backend/memory.py
@@ -37,9 +37,9 @@ class Memory(BackendBase):
         """
         previous = self._timestamps[resource_name].get(user_id)
         current = utils.msec_time()
-        if previous and previous == current:
-            current += 1
-        self._timestamps[user_id] = current
+        if previous and previous >= current:
+            current = previous + 1
+        self._timestamps[resource_name][user_id] = current
         return current
 
     def create(self, resource, user_id, record):

--- a/readinglist/backend/memory.py
+++ b/readinglist/backend/memory.py
@@ -30,8 +30,9 @@ class Memory(BackendBase):
 
         .. note ::
 
-            Here it is assumed that requests from the same user won't burst
-            several time per millisecond.
+            Here it is assumed that if requests from the same user burst in,
+            the time will slide into the future. It is not problematic since
+            the timestamp notion is opaque, and behaves like a revision number.
         """
         previous = self._timestamps.get(user_id)
         current = utils.msec_time()

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -43,14 +43,14 @@ def validates_or_400():
     return wrap
 
 
-def refresh_revision():
-    """View decorator to refresh the request revision, because it was
+def refresh_timestamp():
+    """View decorator to refresh the request timestamp, because it was
     incremented during the view execution."""
     def wrap(view):
         def wrapped_view(self, *args, **kwargs):
             result = view(self, *args, **kwargs)
             user_id = self.request.authenticated_userid
-            self.request.revision = self.db.revision(user_id)
+            self.request.timestamp = self.db.timestamp(user_id)
             return result
         return wrapped_view
     return wrap
@@ -245,7 +245,7 @@ class BaseResource(object):
         return body
 
     @resource.view(permission='readwrite', with_schema=True)
-    @refresh_revision()
+    @refresh_timestamp()
     def collection_post(self):
         new_record = self.process_record(self.request.validated)
         self.record = self.db.create(record=new_record, **self.db_kwargs)
@@ -260,7 +260,7 @@ class BaseResource(object):
         return self.record
 
     @resource.view(permission='readwrite', with_schema=True)
-    @refresh_revision()
+    @refresh_timestamp()
     def put(self):
         record_id = self.request.matchdict['id']
 
@@ -279,7 +279,7 @@ class BaseResource(object):
     @resource.view(permission='readwrite')
     @exists_or_404()
     @validates_or_400()
-    @refresh_revision()
+    @refresh_timestamp()
     def patch(self):
         record_id = self.request.matchdict['id']
         self.record = self.db.get(record_id=record_id, **self.db_kwargs)
@@ -295,7 +295,7 @@ class BaseResource(object):
 
     @resource.view(permission='readwrite')
     @exists_or_404()
-    @refresh_revision()
+    @refresh_timestamp()
     def delete(self):
         record_id = self.request.matchdict['id']
         self.record = self.db.delete(record_id=record_id, **self.db_kwargs)

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -120,7 +120,7 @@ class BaseResource(object):
         """
         timestamp = self.db.timestamp(**self.db_kwargs)
         timestamp = six.text_type(timestamp).encode('utf-8')
-        self.request.response.headers['Timestamp'] = timestamp
+        self.request.response.headers['Last-Modified'] = timestamp
 
     def process_record(self, new, old=None):
         """Hook to post-process records and introduce specific logics

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -43,19 +43,6 @@ def validates_or_400():
     return wrap
 
 
-def refresh_timestamp():
-    """View decorator to refresh the request timestamp, because it was
-    incremented during the view execution."""
-    def wrap(view):
-        def wrapped_view(self, *args, **kwargs):
-            result = view(self, *args, **kwargs)
-            user_id = self.request.authenticated_userid
-            self.request.timestamp = self.db.timestamp(user_id)
-            return result
-        return wrapped_view
-    return wrap
-
-
 class TimeStamp(colander.SchemaNode):
     """Basic integer field that takes current timestamp if no value
     is provided.
@@ -127,6 +114,13 @@ class BaseResource(object):
                               user_id=request.authenticated_userid)
         self.record = None
         self.known_fields = [c.name for c in self.mapping.children]
+
+    def add_timestamp_header(self):
+        """Add current timestamp in response headers, when request comes in.
+        """
+        timestamp = self.db.timestamp(**self.db_kwargs)
+        timestamp = six.text_type(timestamp).encode('utf-8')
+        self.request.response.headers['Timestamp'] = timestamp
 
     def process_record(self, new, old=None):
         """Hook to post-process records and introduce specific logics
@@ -230,6 +224,8 @@ class BaseResource(object):
 
     @resource.view(permission='readonly')
     def collection_get(self):
+        self.add_timestamp_header()
+
         filters = self._extract_filters(self.request.GET)
         sorting = self._extract_sorting(self.request.GET)
         records = self.db.get_all(filters=filters,
@@ -245,7 +241,6 @@ class BaseResource(object):
         return body
 
     @resource.view(permission='readwrite', with_schema=True)
-    @refresh_timestamp()
     def collection_post(self):
         new_record = self.process_record(self.request.validated)
         self.record = self.db.create(record=new_record, **self.db_kwargs)
@@ -255,12 +250,13 @@ class BaseResource(object):
     @resource.view(permission='readonly')
     @exists_or_404()
     def get(self):
+        self.add_timestamp_header()
+
         record_id = self.request.matchdict['id']
         self.record = self.db.get(record_id=record_id, **self.db_kwargs)
         return self.record
 
     @resource.view(permission='readwrite', with_schema=True)
-    @refresh_timestamp()
     def put(self):
         record_id = self.request.matchdict['id']
 
@@ -279,7 +275,6 @@ class BaseResource(object):
     @resource.view(permission='readwrite')
     @exists_or_404()
     @validates_or_400()
-    @refresh_timestamp()
     def patch(self):
         record_id = self.request.matchdict['id']
         self.record = self.db.get(record_id=record_id, **self.db_kwargs)
@@ -295,7 +290,6 @@ class BaseResource(object):
 
     @resource.view(permission='readwrite')
     @exists_or_404()
-    @refresh_timestamp()
     def delete(self):
         record_id = self.request.matchdict['id']
         self.record = self.db.delete(record_id=record_id, **self.db_kwargs)

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -7,7 +7,7 @@ from cornice import resource
 
 from readinglist.backend.exceptions import RecordNotFoundError
 from readinglist.errors import json_error, ImmutableFieldError
-from readinglist.utils import COMPARISON, native_value, time_second
+from readinglist.utils import COMPARISON, native_value, msec_time
 
 
 def exists_or_404():
@@ -67,7 +67,7 @@ class TimeStamp(colander.SchemaNode):
 
     def deserialize(self, cstruct=colander.null):
         if cstruct is colander.null and self.auto_now:
-            cstruct = time_second()
+            cstruct = msec_time()
         return super(TimeStamp, self).deserialize(cstruct)
 
 

--- a/readinglist/tests/test_backend.py
+++ b/readinglist/tests/test_backend.py
@@ -21,7 +21,7 @@ class BackendBaseTest(unittest.TestCase):
         calls = [
             (self.backend.flush,),
             (self.backend.ping,),
-            (self.backend.timestamp, ''),
+            (self.backend.timestamp, '', ''),
             (self.backend.create, '', '', {}),
             (self.backend.get, '', '', ''),
             (self.backend.update, '', '', '', {}),

--- a/readinglist/tests/test_backend.py
+++ b/readinglist/tests/test_backend.py
@@ -21,7 +21,7 @@ class BackendBaseTest(unittest.TestCase):
         calls = [
             (self.backend.flush,),
             (self.backend.ping,),
-            (self.backend.revision, ''),
+            (self.backend.timestamp, ''),
             (self.backend.create, '', '', {}),
             (self.backend.get, '', '', ''),
             (self.backend.update, '', '', '', {}),

--- a/readinglist/tests/test_schemas.py
+++ b/readinglist/tests/test_schemas.py
@@ -8,7 +8,7 @@ from .support import unittest
 
 
 class TimeStampTest(unittest.TestCase):
-    @mock.patch('readinglist.resource.time_second')
+    @mock.patch('readinglist.resource.msec_time')
     def test_default_value_comes_from_timestamper(self, time_mocked):
         time_mocked.return_value = 666
         default = TimeStamp().deserialize(colander.null)

--- a/readinglist/tests/test_views_article.py
+++ b/readinglist/tests/test_views_article.py
@@ -179,7 +179,7 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
         resp = self.app.post_json('/articles', article, headers=self.headers)
         modification = resp.json['last_modified']
         resp = self.app.get('/articles', headers=self.headers)
-        header = int(resp.headers['Timestamp'])
+        header = int(resp.headers['Last-Modified'])
         self.assertEqual(header, modification)
 
     def test_filter_with_since_accepts_numeric_value(self):
@@ -202,7 +202,7 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
     def test_filter_from_last_header_value_is_exclusive(self):
         resp = self.app.get('/articles', headers=self.headers)
 
-        current = int(resp.headers['Timestamp'])
+        current = int(resp.headers['Last-Modified'])
         url = '/articles?_since={0}'.format(current)
 
         resp = self.app.get(url, headers=self.headers)
@@ -226,7 +226,7 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
 
         def read_timestamp():
             resp = self.app.head('/articles', headers=self.headers)
-            return int(resp.headers['Timestamp'])
+            return int(resp.headers['Last-Modified'])
 
         before = read_timestamp()
         now = read_timestamp()
@@ -280,7 +280,7 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
             with mock.patch.object(self.db, 'get_all', delayed_get):
                 resp = self.app.head('/articles',
                                      headers=self.headers)
-                timestamps['fetch'] = int(resp.headers['Timestamp'])
+                timestamps['fetch'] = int(resp.headers['Last-Modified'])
 
         # Create a real record with no patched timestamp
         self.app.post_json('/articles',

--- a/readinglist/tests/test_views_article.py
+++ b/readinglist/tests/test_views_article.py
@@ -247,6 +247,25 @@ class ArticleFilterModifiedTest(BaseWebTest, unittest.TestCase):
         after = read_timestamp()
         self.assertTrue(before < now < after)
 
+    def test_timestamp_are_always_incremented_above_existing_value(self):
+        # Create a record with normal clock
+        resp = self.app.post_json('/articles',
+                                  MINIMALIST_ARTICLE,
+                                  headers=self.headers)
+        current = int(resp.json['last_modified'])
+
+        # Patch the clock to return a time in the past
+        with mock.patch('readinglist.utils.msec_time') as time_mocked:
+            time_mocked.return_value = -1
+
+            resp = self.app.post_json('/articles',
+                                      MINIMALIST_ARTICLE,
+                                      headers=self.headers)
+            after = int(resp.json['last_modified'])
+
+        # Expect the current last-modified to be based on the highest value
+        self.assertTrue(current < after)
+
     def test_records_created_during_fetch_are_above_fetch_timestamp(self):
 
         timestamps = {}

--- a/readinglist/tests/test_views_hello.py
+++ b/readinglist/tests/test_views_hello.py
@@ -17,10 +17,6 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         response = self.app.get('/')
         self.assertEqual(response.json['eos'], None)
 
-    def test_a_timestamp_header_is_provided_in_responses(self):
-        response = self.app.get('/')
-        self.assertIsNotNone(response.headers.get('Timestamp'))
-
     def test_redirect_to_version(self):
         # We don't want the prefix to be automatically added for this test.
         original_request_class = self.app.RequestClass

--- a/readinglist/utils.py
+++ b/readinglist/utils.py
@@ -12,7 +12,6 @@ from colander import null
 # removes whitespace, newlines, and tabs from the beginning/end of a string
 strip_whitespace = lambda v: v.strip(' \t\n\r') if v is not null else v
 
-time_second = lambda: int(time.time())
 msec_time = lambda: int(time.time() * 1000.0)  # floor
 
 


### PR DESCRIPTION
* Renamed revision to timestamp
* Base timestamp on current millisecond
* Slide into the future when a time collision occurs
* Put millisecond timestamps everywhere (eg. ``stored_on``)