### PR TITLE
mark as read doesn't handle the marked_read_by parameter.

### DIFF
--- a/readinglist/tests/test_views_article.py
+++ b/readinglist/tests/test_views_article.py
@@ -62,6 +62,21 @@ class ArticleModificationTest(BaseWebTest, unittest.TestCase):
         self.assertIsNone(resp.json['marked_read_by'])
         self.assertIsNone(resp.json['marked_read_on'])
 
+    def test_patch_marked_read_are_taken_into_account(self):
+        mark_read = {
+            'unread': False,
+            'marked_read_by': 'FxOS',
+            'marked_read_on': 1234}
+        resp = self.app.patch_json(self.url, mark_read, headers=self.headers)
+        body = resp.json
+        self.assertEqual(body['marked_read_by'], mark_read['marked_read_by'])
+        self.assertEqual(body['marked_read_on'], mark_read['marked_read_on'])
+
+        resp = self.app.get(self.url, headers=self.headers)
+        body = resp.json
+        self.assertEqual(body['marked_read_by'], mark_read['marked_read_by'])
+        self.assertEqual(body['marked_read_on'], mark_read['marked_read_on'])
+
     def test_cannot_modify_url(self):
         body = {'url': 'http://immutable.org'}
         self.app.patch_json(self.url,


### PR DESCRIPTION
I tried to mark my article as read using:

    http PATCH https://readinglist.dev.mozaws.net/v0/articles/132cdcbc40374097834134c8cc8b1b8a \ 
        Authorization:"Bearer <token>" \
        marked_read_by=Inspiron marked_read_on=1422691406308 unread=False

But as a matter of fact the marked_read_by parameter is not taken into account.