### PR TITLE
Create userid based on userid hmac.

### DIFF
--- a/config/readinglist.ini
+++ b/config/readinglist.ini
@@ -7,7 +7,7 @@ readinglist.retry_after = 30
 readinglist.eos =
 # readinglist.basic_auth_backdoor = true
 # readinglist.backoff = 10
-readinglist.userid_hmac_key = b4c96a8692291d88fe5a97dd91846eb4
+readinglist.userid_hmac_secret = b4c96a8692291d88fe5a97dd91846eb4
 
 fxa-oauth.client_id =
 fxa-oauth.client_secret =

--- a/config/readinglist.ini
+++ b/config/readinglist.ini
@@ -7,6 +7,7 @@ readinglist.retry_after = 30
 readinglist.eos =
 # readinglist.basic_auth_backdoor = true
 # readinglist.backoff = 10
+readinglist.userid_hmac_key = b4c96a8692291d88fe5a97dd91846eb4
 
 fxa-oauth.client_id =
 fxa-oauth.client_secret =

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -1,6 +1,8 @@
 import mock
 import threading
 import webtest
+import hashlib
+import hmac
 
 try:
     import unittest2 as unittest

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -1,8 +1,6 @@
 import mock
 import threading
 import webtest
-import hashlib
-import hmac
 
 try:
     import unittest2 as unittest
@@ -10,6 +8,7 @@ except ImportError:
     import unittest  # NOQA
 
 from readinglist import API_VERSION
+from readinglist.utils import random_bytes_hex
 
 
 class PrefixedRequestClass(webtest.app.TestRequest):
@@ -36,6 +35,8 @@ class FakeAuthentMixin(object):
 
         self.app.app.registry.settings.setdefault('fxa-oauth.oauth_uri', '')
         self.app.app.registry.settings.setdefault('fxa-oauth.scope', '')
+        self.app.app.registry.settings.setdefault(
+            'readinglist.userid_hmac_key', random_bytes_hex(16))
 
         self.fxa_verify = self.patcher.start()
         self.fxa_verify.return_value = {

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -33,10 +33,12 @@ class FakeAuthentMixin(object):
     def setUp(self):
         super(FakeAuthentMixin, self).setUp()
 
-        self.app.app.registry.settings.setdefault('fxa-oauth.oauth_uri', '')
-        self.app.app.registry.settings.setdefault('fxa-oauth.scope', '')
-        self.app.app.registry.settings.setdefault(
-            'readinglist.userid_hmac_key', random_bytes_hex(16))
+        settings = self.app.app.registry.settings
+
+        settings.setdefault('fxa-oauth.oauth_uri', '')
+        settings.setdefault('fxa-oauth.scope', '')
+        settings.setdefault('readinglist.userid_hmac_secret',
+                            random_bytes_hex(16))
 
         self.fxa_verify = self.patcher.start()
         self.fxa_verify.return_value = {

--- a/readinglist/tests/test_utils.py
+++ b/readinglist/tests/test_utils.py
@@ -1,6 +1,7 @@
 import colander
+from six import text_type
 
-from readinglist.utils import native_value, strip_whitespace
+from readinglist.utils import native_value, strip_whitespace, random_bytes_hex
 
 from .support import unittest
 
@@ -36,3 +37,21 @@ class StripWhitespaceTest(unittest.TestCase):
 
     def test_idempotent_for_null_values(self):
         self.assertEqual(strip_whitespace(colander.null), colander.null)
+
+
+class CryptographicRandomBytesTest(unittest.TestCase):
+    def test_return_hex_string(self):
+        value = random_bytes_hex(16)
+        try:
+            int(value, 16)
+        except ValueError:
+            self.fail("%s is not an hexadecimal value." % value)
+
+    def test_return_right_length_string(self):
+        for x in range(2, 4):
+            value = random_bytes_hex(x)
+            self.assertEqual(len(value), x * 2)
+
+    def test_return_text_string(self):
+        value = random_bytes_hex(16)
+        self.assertIsInstance(value, text_type)

--- a/readinglist/utils.py
+++ b/readinglist/utils.py
@@ -4,7 +4,9 @@ except ImportError:  # pragma: no cover
     import json  # NOQA
 
 import ast
+import os
 import time
+from binascii import hexlify
 
 from colander import null
 
@@ -16,6 +18,13 @@ msec_time = lambda: int(time.time() * 1000.0)  # floor
 
 # Get a classname from a class.
 classname = lambda c: c.__class__.__name__.lower()
+
+
+def random_bytes_hex(bytes_length):
+    """Return a hexstring of bytes_length cryptographic-friendly random bytes.
+
+    """
+    return hexlify(os.urandom(bytes_length)).decode('utf-8')
 
 
 def native_value(value):


### PR DESCRIPTION
 - username:password for Basic Auth
 - profile user id for Oauth Bearer token

It is important to hmac the Oauth userid in order to keep user privacy in between Oauth servers.
It is important to patch the Basic auth backend to prevent users data to get access with any password.