### PR TITLE
CORS in Cornice error handler

### DIFF
--- a/readinglist/errors.py
+++ b/readinglist/errors.py
@@ -112,4 +112,4 @@ def json_error(errors):
     response = HTTPBadRequest(body=body, content_type='application/json')
     response.status = errors.status
 
-    raise response
+    return response

--- a/readinglist/errors.py
+++ b/readinglist/errors.py
@@ -4,7 +4,7 @@ from pyramid.httpexceptions import (
     HTTPServiceUnavailable as PyramidHTTPServiceUnavailable, HTTPBadRequest,
     HTTPInternalServerError as PyramidHTTPInternalServerError
 )
-from readinglist.utils import Enum, json
+from readinglist.utils import Enum, json, reapply_cors
 
 
 ERRORS = Enum(
@@ -111,5 +111,5 @@ def json_error(errors):
 
     response = HTTPBadRequest(body=body, content_type='application/json')
     response.status = errors.status
-
+    response = reapply_cors(errors.request, response)
     return response

--- a/readinglist/resource.py
+++ b/readinglist/resource.py
@@ -95,7 +95,8 @@ class BaseResource(object):
     def raise_invalid(self, location='body', **kwargs):
         """Helper to raise a validation error."""
         self.request.errors.add(location, **kwargs)
-        raise errors.json_error(self.request.errors)
+        response = errors.json_error(self.request.errors)
+        raise response
 
     def fetch_record(self):
         """Fetch current view related record, and raise 404 if missing."""

--- a/readinglist/tests/resource/test_views.py
+++ b/readinglist/tests/resource/test_views.py
@@ -249,12 +249,24 @@ class CORSHeadersTest(FakeAuthentMixin, BaseWebTest):
                                       status=201)
         self.assertIn('Access-Control-Allow-Origin', response.headers)
 
-    def test_present_on_invalid_record(self):
+    def test_present_on_invalid_record_creation(self):
         body = {'name': 42}
         response = self.app.post_json(self.collection_url,
                                       body,
                                       headers=self.headers,
                                       status=400)
+        self.assertIn('Access-Control-Allow-Origin', response.headers)
+
+    def test_present_on_readonly_update(self):
+        with mock.patch('readinglist.tests.resource.test_views.'
+                        'MushroomSchema.is_readonly',
+                        return_value=True):
+            body = {'name': 'Amanite'}
+            response = self.app.patch_json(self.get_item_url(),
+                                           body,
+                                           headers=self.headers,
+                                           status=400)
+        self.assertEqual(response.json['message'], 'Cannot modify name')
         self.assertIn('Access-Control-Allow-Origin', response.headers)
 
     def test_present_on_unauthorized(self):

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -19,7 +19,7 @@ class DummyRequest(mock.MagicMock):
         self.registry = mock.MagicMock(settings={})
         self.GET = {}
         self.headers = {}
-        self.errors = cornice_errors.Errors()
+        self.errors = cornice_errors.Errors(request=self)
         self.authenticated_userid = 'bob'
         self.validated = {}
         self.matchdict = {}

--- a/readinglist/views/errors.py
+++ b/readinglist/views/errors.py
@@ -1,6 +1,5 @@
 from functools import wraps
 
-from cornice.cors import ensure_origin
 from pyramid import httpexceptions
 from pyramid.security import forget
 from pyramid.view import (
@@ -9,23 +8,7 @@ from pyramid.view import (
 
 from readinglist import logger
 from readinglist.errors import format_error, ERRORS, HTTPInternalServerError
-
-
-def reapply_cors(request, response):
-    """Reapply cors headers to the new response with regards to the request.
-
-    We need to re-apply the CORS checks done by Cornice, in case we're
-    recreating the response from scratch.
-
-    """
-    if request.matched_route:
-        services = request.registry.cornice_services
-        pattern = request.matched_route.pattern
-        service = services.get(pattern, None)
-
-        request.info['cors_checked'] = False
-        response = ensure_origin(service, request, response)
-    return response
+from readinglist.utils import reapply_cors
 
 
 def cors(view):


### PR DESCRIPTION
I fixed the problem of Cors, but not at the right place IHMO.

 I think it put the light on a problem of application setup (?)

Indeed, when [running the app from tests](https://github.com/mozilla-services/readinglist/blob/master/readinglist/tests/resource/test_views.py#L29-L44), the [view config hook](https://github.com/mozilla-services/readinglist/blob/master/readinglist/views/errors.py#L80-L84) is executed when a bad request is raised. It is not the case when running the app through readinglist.main (i.e. make serve)