### PR TITLE
Default permissions override OPTIONS permissions.

### DIFF
--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -55,7 +55,6 @@ def set_auth(config):
 
     config.set_authorization_policy(authz_policy)
     config.set_authentication_policy(authn_policy)
-    config.set_default_permission('readwrite')
 
 
 def attach_http_objects(config):

--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -55,6 +55,8 @@ def set_auth(config):
 
     config.set_authorization_policy(authz_policy)
     config.set_authentication_policy(authn_policy)
+    # XXX: Should be restore as soon as Cornice is fixed (see #273)
+    # config.set_default_permission('readwrite')
 
 
 def attach_http_objects(config):

--- a/readinglist/tests/test_views_article.py
+++ b/readinglist/tests/test_views_article.py
@@ -27,6 +27,13 @@ class IntegrationTest(BaseWebTest, unittest.TestCase):
                                  status=405)
         self.assertEqual(resp.json['errno'], 115)
 
+    def test_options_on_articles_works(self):
+        self.app.options(
+            '/articles',
+            headers={'Access-Control-Request-Method': 'GET',
+                     'Origin': 'http://localhost/'},
+            status=200)
+
 
 class ArticleModificationTest(BaseWebTest, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Cornice need a patch, see https://github.com/mozilla-services/cornice/issues/273