### PR TITLE
Fixed fxa-oauth.oauth_uri.

### DIFF
--- a/config/readinglist.ini
+++ b/config/readinglist.ini
@@ -13,7 +13,7 @@ readinglist.userid_hmac_secret = b4c96a8692291d88fe5a97dd91846eb4
 
 fxa-oauth.client_id = 89513028159972bc
 fxa-oauth.client_secret = 9aced230585cc0aa2932e2eb871c9a3a7d6458e59ccf57eb610ea0a3467dd800
-fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org/v1
+fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org
 fxa-oauth.scope = profile
 
 


### PR DESCRIPTION
The default configuration value for `fxa-oauth.oauth_uri` has an erroneous `/v1` path set; this patch fixes that.