### PR TITLE
Truncate titles if too long instead of rejecting them

### DIFF
--- a/readinglist/tests/test_schemas.py
+++ b/readinglist/tests/test_schemas.py
@@ -91,15 +91,13 @@ class ArticleSchemaTest(unittest.TestCase):
 
     def test_title_has_max_length(self):
         self.record['title'] = u'\u76d8' * 1025
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          self.record)
+        deserialized = self.schema.deserialize(self.record)
+        self.assertEqual(len(deserialized['title']), 1024)
 
     def test_resolved_title_has_max_length(self):
         self.record['resolved_title'] = u'\u76d8' * 1025
-        self.assertRaises(colander.Invalid,
-                          self.schema.deserialize,
-                          self.record)
+        deserialized = self.schema.deserialize(self.record)
+        self.assertEqual(len(deserialized['resolved_title']), 1024)
 
     def test_resolved_title_is_stripped(self):
         self.record['resolved_title'] = '  Nous Sommes Charlie  '

--- a/readinglist/views/article.py
+++ b/readinglist/views/article.py
@@ -8,6 +8,8 @@ from readinglist.resource import crud, BaseResource, ResourceSchema, TimeStamp
 from readinglist.utils import strip_whitespace
 from readinglist.schema import URL
 
+TITLE_MAX_LENGTH = 1024
+
 
 class DeviceName(SchemaNode):
     """String representing the device name."""
@@ -21,10 +23,13 @@ class DeviceName(SchemaNode):
 class ArticleTitle(SchemaNode):
     """String representing the title of an article."""
     schema_type = String
-    validator = colander.Length(min=1, max=1024)
+    validator = colander.Length(min=1, max=TITLE_MAX_LENGTH)
 
     def preparer(self, appstruct):
-        return strip_whitespace(appstruct)
+        if appstruct:
+            return strip_whitespace(appstruct)[:TITLE_MAX_LENGTH]
+        else:
+            return appstruct
 
 
 class ArticleSchema(ResourceSchema):

--- a/readinglist/views/article.py
+++ b/readinglist/views/article.py
@@ -27,6 +27,7 @@ class ArticleTitle(SchemaNode):
 
     def preparer(self, appstruct):
         if appstruct:
+            # Strip then truncate the title to TITLE_MAX_LENGTH
             return strip_whitespace(appstruct)[:TITLE_MAX_LENGTH]
         else:
             return appstruct


### PR DESCRIPTION
Could also be applied to URLs ? https://github.com/mozilla-services/readinglist/pull/55#discussion_r23532001
(seems a bit brutal)