### PR TITLE
Add configuration reporting endpoint

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -13,7 +13,11 @@ Use the OAuth token with this header:
 
     Authorization: Bearer <oauth_token>
 
-**Obtain the token**
+Obtain the token
+----------------
+
+Using the Web UI
+::::::::::::::::
 
 * Navigate the client to ``GET /v1/fxa-oauth/login?redirect=http://app-endpoint/#``. There, a session
   cookie will be set, and the client will be redirected to a login
@@ -21,7 +25,41 @@ Use the OAuth token with this header:
 * After submitting the credentials on the login page, the client will
   be redirected to ``http://app-endpoint/#{token}`` the web-app.
 
-**Reading list scope**
+
+Using another flow
+::::::::::::::::::
+
+In case you need to have some configurations in order to trade your
+Firefox Account BrowserID assertion with a Bearer Token, you can use
+the ``GET /v1/fxa-oauth/params`` endpoint.
+
+.. code-block:: http
+
+    $ http GET http://localhost:8000/v0/fxa-oauth/params -v
+
+    GET /v0/fxa-oauth/params HTTP/1.1
+    Accept: */*
+    Accept-Encoding: gzip, deflate
+    Host: localhost:8000
+    User-Agent: HTTPie/0.8.0
+
+
+    HTTP/1.1 200 OK
+    Content-Length: 103
+    Content-Type: application/json; charset=UTF-8
+    Date: Thu, 19 Feb 2015 09:28:37 GMT
+    Server: waitress
+
+    {
+        "client_id": "89513028159972bc", 
+        "oauth_uri": "https://oauth-stable.dev.lcip.org", 
+        "scope": "profile"
+    }
+
+
+
+Reading list scope
+------------------
 
 The *Reading List* API will eventually have to handle a dedicated OAuth scope (e.g.
 ``readinglist``, ``readinglist:read``, ``readinglist:write``). This will help users

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -26,12 +26,13 @@ Using the Web UI
   be redirected to ``http://app-endpoint/#{token}`` the web-app.
 
 
-Using another flow
-::::::::::::::::::
+Custom flow
+:::::::::::
 
-In case you need to have some configurations in order to trade your
-Firefox Account BrowserID assertion with a Bearer Token, you can use
-the ``GET /v1/fxa-oauth/params`` endpoint.
+The ``GET /v1/fxa-oauth/params`` endpoint can be use to get the
+configuration in order to trade the Firefox Account BrowserID with a
+Bearer Token. `See Firefox Account documentation about this behavior
+<https://developer.mozilla.org/en-US/Firefox_Accounts#Firefox_Accounts_BrowserID_API>`_
 
 .. code-block:: http
 

--- a/readinglist/tests/test_views_oauth.py
+++ b/readinglist/tests/test_views_oauth.py
@@ -34,6 +34,25 @@ class LoginViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(r.headers['Location'], expected_redirect)
 
 
+class ParamsViewTest(BaseWebTest, unittest.TestCase):
+    url = '/fxa-oauth/params'
+
+    def test_params_view_give_back_needed_values(self):
+        settings = self.app.app.registry.settings
+        oauth_endpoint = settings.get('fxa-oauth.oauth_uri')
+        client_id = settings.get('fxa-oauth.client_id')
+        scope = settings.get('fxa-oauth.scope')
+        expected_body = {
+            "client_id": client_id,
+            "oauth_uri": oauth_endpoint,
+            "scope": scope
+        }
+
+        r = self.app.get(self.url)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json, expected_body)
+
+
 class TokenViewTest(BaseWebTest, unittest.TestCase):
     url = '/fxa-oauth/token'
 

--- a/readinglist/views/oauth.py
+++ b/readinglist/views/oauth.py
@@ -14,6 +14,7 @@ from readinglist.views.errors import authorization_required
 from readinglist import logger
 
 login = Service(name='fxa-oauth-login', path='/fxa-oauth/login')
+params = Service(name='fxa-oauth-params', path='/fxa-oauth/params')
 token = Service(name='fxa-oauth-token', path='/fxa-oauth/token')
 
 
@@ -47,6 +48,17 @@ def fxa_oauth_login(request):
     request.response.status_code = 302
     request.response.headers['Location'] = form_url
     return {}
+
+
+@params.get(permission=NO_PERMISSION_REQUIRED)
+def fxa_oauth_params(request):
+    """Helper to give Firefox Account configuration information."""
+    settings = request.registry.settings
+    return {
+        "client_id": settings.get('fxa-oauth.client_id'),
+        "oauth_uri": settings.get('fxa-oauth.oauth_uri'),
+        "scope": settings.get('fxa-oauth.scope'),
+    }
 
 
 class OAuthRequest(MappingSchema):


### PR DESCRIPTION
@ckarlof told me that the Loop service provided configuration (URLs, etc).  It would be nice to get the oauth and auth servers, at least.  Point me at the endpoint if this already exists!