### PR TITLE
"fatal error: 'ffi.h' file not found" error when installing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,26 @@ To restart it (Bug after configuration update)::
     brew services restart redis
 
 
+Install libffi
+==============
+
+Linux
+-----
+
+On debian / ubuntu based systems::
+
+    apt-get install libffi-dev
+
+
+OS X
+----
+
+Assuming `brew <http://brew.sh/>`_ is installed, libffi installation becomes:
+
+::
+
+    brew install libffi pkg-config
+
 
 
 Run tests


### PR DESCRIPTION
### Steps to reproduce:
```sh
$ git clone git@github.com:mozilla-services/readinglist.git
$ cd readinglist
$ make serve
```

### Actual results:
```sh
...
Installed /private/var/folders/qc/g_f0szh95k1fzph34rhmf5jw0000gp/T/easy_install-Bb7Dm3/cryptography-0.7.2/pyasn1-0.1.7-py2.7.egg
Searching for cffi>=0.8
Reading https://pypi.python.org/simple/cffi/
Best match: cffi 0.8.6
Downloading https://pypi.python.org/packages/source/c/cffi/cffi-0.8.6.tar.gz#md5=474b5a68299a6f05009171de1dc91be6
Processing cffi-0.8.6.tar.gz
Writing /var/folders/qc/g_f0szh95k1fzph34rhmf5jw0000gp/T/easy_install-Bb7Dm3/cryptography-0.7.2/temp/easy_install-p_rzMX/cffi-0.8.6/setup.cfg
Running cffi-0.8.6/setup.py -q bdist_egg --dist-dir /var/folders/qc/g_f0szh95k1fzph34rhmf5jw0000gp/T/easy_install-Bb7Dm3/cryptography-0.7.2/temp/easy_install-p_rzMX/cffi-0.8.6/egg-dist-tmp-LGxd15
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing 'libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing 'libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing 'libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing 'libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing 'libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
compiling '_configtest.c':
__thread int some_threadlocal_variable_42;

cc -fno-strict-aliasing -fno-common -dynamic -arch x86_64 -arch i386 -g -Os -pipe -fno-common -fno-strict-aliasing -fwrapv -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -Wstrict-prototypes -Wshorten-64-to-32 -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -DENABLE_DTRACE -arch x86_64 -arch i386 -pipe -c _configtest.c -o _configtest.o
success!
removing: _configtest.c _configtest.o
c/_cffi_backend.c:13:10: fatal error: 'ffi.h' file not found
#include <ffi.h>
         ^
1 error generated.
error: Setup script exited with error: command 'cc' failed with exit status 1
make: *** [.venv/.install.stamp] Error 1
```

Not sure if I'm missing some other library or something else.
I'm using Mac OSX 10.10.2 and Python 2.7.6.
