### PR TITLE
Centos 7 build changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,9 @@ $(INSTALL_STAMP): $(PYTHON) setup.py
 	$(VENV)/bin/pip install --process-dependency-links -U -e .
 	touch $(INSTALL_STAMP)
 
-install-dev: install $(DEV_STAMP)
-$(DEV_STAMP): $(PYTHON) dev-requirements.txt
-	$(VENV)/bin/pip install -r dev-requirements.txt
-	touch $(DEV_STAMP)
+install-dev:
+        $(VENV)/bin/pip install -r dev-requirements.txt
+        touch $(DEV_STAMP)
 
 virtualenv: $(PYTHON)
 $(PYTHON):

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(INSTALL_STAMP): $(PYTHON) setup.py
 	$(VENV)/bin/pip install --process-dependency-links -U -e .
 	touch $(INSTALL_STAMP)
 
-install-dev:
+install-dev: virtualenv
         $(VENV)/bin/pip install -r dev-requirements.txt
         touch $(DEV_STAMP)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+pip==6.0.8
 WebTest
 nose
 nose-cov


### PR DESCRIPTION
You probably don't want to merge this as is, but I wasn't able to build on Centos 7 without upgrading pip to a version that supports the (now deprecated) --process-dependency-links option.