### PR TITLE
Fixing example snippets

### DIFF
--- a/docs/resource.rst
+++ b/docs/resource.rst
@@ -285,6 +285,7 @@ Example
 -------
 
 ::
+
     http POST http://localhost:8000/v1/articles \
         title="The Hawk Authorization protocol" \
         url=https://blog.mozilla.org/services/2015/02/05/whats-hawk-and-how-to-use-it/ \
@@ -406,6 +407,7 @@ Example
 -------
 
 ::
+
     http GET http://localhost:8000/v1/articles/30afb809ca7745a58496a09c6a4afcac \
         --auth "admin:" -v
 


### PR DESCRIPTION
Seems like they were missing a space and not rendering properly:

![readinglist_resource_rst_at_master_ _mozilla-services_readinglist](https://cloud.githubusercontent.com/assets/557895/6649074/c1b0df90-c99f-11e4-8aa7-9d5a431f7b90.png)
**Figure 1:** Example on GitHub (Before)

---

![resource_endpoints_ _reading_list_1_0_documentation](https://cloud.githubusercontent.com/assets/557895/6649085/0ad87084-c9a0-11e4-8c6c-8b981adf7c47.png)
**Figure 2:** Example on https://readinglist.readthedocs.org/en/latest/resource.html#post-articles (Before)