### PR TITLE
Error when running `make smoke` load test

### DIFF
--- a/loadtests/config/smoke.ini
+++ b/loadtests/config/smoke.ini
@@ -1,0 +1,10 @@
+[loads]
+users = 10
+duration = 60
+include_file = loadtest
+agents = 5
+detach = true
+observer = irc
+ssh = ubuntu@loads.services.mozilla.com
+no-dns-resolve = true
+broker = tcp://172.31.44.86:7780


### PR DESCRIPTION
I'm getting the following error when running [`$ make smoke`](
https://github.com/mozilla-services/readinglist/blob/8516cd5369c66e29661c10ad1a7e0d3603e0eea1/loadtests/Makefile#L43-L44):

```sh
$ make smoke

.venv/bin/loads-runner --config=./config/smoke.ini --user-id=pdehaan --server-url=http://localhost:8000 loadtest.TestBasic.test_all
Traceback (most recent call last):
  File ".venv/bin/loads-runner", line 9, in <module>
    load_entry_point('loads==0.3', 'console_scripts', 'loads-runner')()
  File "/Users/pdehaan/dev/github/readinglist/loadtests/.venv/lib/python2.7/site-packages/loads/main.py", line 268, in main
    args, parser = _parse(sysargs)
  File "/Users/pdehaan/dev/github/readinglist/loadtests/.venv/lib/python2.7/site-packages/loads/main.py", line 256, in _parse
    if 'fqn' in config['loads']:
  File "/Users/pdehaan/dev/github/readinglist/loadtests/.venv/lib/python2.7/site-packages/configparser.py", line 995, in __getitem__
    raise KeyError(key)
KeyError: 'loads'
make: *** [smoke] Error 1
```

Me thinks the problem is that `$ make smoke` mentions some `--config=./config/smoke.ini` config but there isn't a "smoke.ini" in the [./config/](https://github.com/mozilla-services/readinglist/tree/master/loadtests/config) directory.