### PR TITLE
Rename fxa-oauth.enabled into fxa-oauth.relier.enabled

### DIFF
--- a/config/readinglist.ini
+++ b/config/readinglist.ini
@@ -22,7 +22,7 @@ fxa-oauth.client_secret = 9aced230585cc0aa2932e2eb871c9a3a7d6458e59ccf57eb610ea0
 fxa-oauth.oauth_uri = https://oauth-stable.dev.lcip.org
 fxa-oauth.scope = readinglist
 fxa-oauth.webapp.redirect_url = "http://localhost:4000#auth:"
-fxa-oauth.enabled = false
+fxa-oauth.relier.enabled = false
 
 
 [server:main]


### PR DESCRIPTION
Dependent on mozilla-services/cliquet#97