### PR TITLE
Use PyFxA for dynamic load testing

### DIFF
--- a/config/readinglist.ini
+++ b/config/readinglist.ini
@@ -36,11 +36,18 @@ port = 8000
 
 [uwsgi]
 wsgi-file = app.wsgi
-http = :8000
 enable-threads = true
+http = 127.0.0.1:8000
+processes = 10
 master = true
-processes = 1
-virtualenv = .
+module = readinglist
+harakiri = 30
+uid = readinglist
+gid = readinglist
+virtualenv = .venv
+lazy = true
+lazy-apps = true
+single-interpreter = true
 
 
 # Begin logging configuration

--- a/loadtests/Makefile
+++ b/loadtests/Makefile
@@ -18,7 +18,8 @@ $(PYTHON):
 
 # Build virtualenv, to ensure we have all the dependencies.
 .env.install: $(PYTHON)
-	$(INSTALL) git+git://github.com/mozilla-services/loads.git  >> loadtest.log && \
+	$(INSTALL) git+git://github.com/mozilla-services/loads.git >> loadtest.log && \
+	$(INSTALL) PyFxA >> loadtest.log && \
 	rm loadtest.log || cat loadtest.log
 	touch $@
 

--- a/loadtests/config/megabench.ini
+++ b/loadtests/config/megabench.ini
@@ -8,3 +8,4 @@ observer = irc
 ssh = ubuntu@loads.services.mozilla.com
 no-dns-resolve = true
 broker = tcp://172.31.44.86:7780
+python-dep = PyFxA

--- a/loadtests/config/smoke.ini
+++ b/loadtests/config/smoke.ini
@@ -2,5 +2,5 @@
 no-dns-resolve = true
 include_file = loadtest/*.py, config/*.ini
 smoke = True
-; This is the bearer token of the readinglist-loadtest@restmail.net user
-token = 860c8829667b602914f607354e0992afcd55e6232e15ac0f0b80af8661954b18
+fxa-url = https://api.accounts.firefox.com
+fxa-client-id = 5882386c6d801776


### PR DESCRIPTION
This is a test with PyFxA for dynamic email creations.

Currently, the emails on the restmail service aren't here when it checks and as such it fails. When adding a manual sleep, for whatever raison it claims the assertion is invalid.

@rfk thoughts ?