### PR TITLE
IndexError: list index out of range

### DIFF
--- a/loadtests/loadtest/__init__.py
+++ b/loadtests/loadtest/__init__.py
@@ -79,9 +79,10 @@ class TestBasic(TestCase):
 
             This method is called as many times as number of hits.
         """
-        while self.nb_initial_records > 0:
+        nb_initial_records = self.nb_initial_records
+        while nb_initial_records > 0:
             self.create()
-            self.nb_initial_records -= 1
+            nb_initial_records -= 1
 
         resp = self.session.get(self.api_url('articles'), auth=self.auth)
         records = resp.json()['items']


### PR DESCRIPTION
Was running a load test against **readinglist@1.5.0** on stage for @micheletto and got a few errors when running `make test` (a humble 300 request load test), and got:

Success: 218
Errors: 82
Failures: 0

```
$ http GET https://readinglist.stage.mozaws.net/v1/
HTTP/1.1 200 OK
Access-Control-Expose-Headers: Backoff, Retry-After, Alert
Backoff: None
Connection: keep-alive
Content-Length: 152
Content-Type: application/json; charset=UTF-8
Date: Thu, 02 Apr 2015 01:05:16 GMT

{
    "documentation": "https://readinglist.readthedocs.org/",
    "hello": "readinglist",
    "url": "https://readinglist.stage.mozaws.net/v1/",
    "version": "1.5.0"
}
```

```ini
[loads]
hits = 100
users = 3
no-dns-resolve = true
include_file = loadtest/*.py
```

```
$ make smoke
.venv/bin/loads-runner --config=./config/smoke.ini --user-id=pdehaan --server-url=https://readinglist.stage.mozaws.net:443 loadtest.TestBasic.test_all

Duration: 15.81 seconds
Hits: 69
Started: 2015-04-02 01:01:18.043551
Approximate Average RPS: 4
Average request time: 0.22s
Opened web sockets: 0
Bytes received via web sockets : 0

Success: 1
Errors: 0
Failures: 0


Slowest URL: https://readinglist.stage.mozaws.net:443/v1/articles 	Average Request Time: 0.219791735294

Stats by URLs:
- https://readinglist.stage.mozaws.net:443/v1/articles                     	Average request time: 0.219791735294	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/articles?_since=1427936493349	Average request time: 0.092926	Hits success rate: 1.0

Custom metrics:
- 201 : 67
- poll_changes : 1
```

```
$ make test
.venv/bin/loads-runner --config=./config/test.ini --server-url=https://readinglist.stage.mozaws.net:443 loadtest.TestBasic.test_all

Duration: 71.79 seconds
Hits: 842
Started: 2015-04-02 01:01:42.537012
Approximate Average RPS: 11
Average request time: 0.17s
Opened web sockets: 0
Bytes received via web sockets : 0

Success: 218
Errors: 82
Failures: 0

1 occurrences of:
    IndexError: list index out of range    Traceback:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 322, in run
    self.setUp()
  File "loadtest/__init__.py", line 90, in setUp
    self.random_record = random.choice(records)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.py", line 273, in choice
    return seq[int(self.random() * len(seq))]  # raises IndexError if seq is empty
1 occurrences of:
    IndexError: list index out of range    Traceback:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 322, in run
    self.setUp()
  File "loadtest/__init__.py", line 90, in setUp
    self.random_record = random.choice(records)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.py", line 273, in choice
    return seq[int(self.random() * len(seq))]  # raises IndexError if seq is empty
1 occurrences of:
    IndexError: list index out of range    Traceback:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 322, in run
    self.setUp()
  File "loadtest/__init__.py", line 90, in setUp
    self.random_record = random.choice(records)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.py", line 273, in choice
    return seq[int(self.random() * len(seq))]  # raises IndexError if seq is empty


Slowest URL: https://readinglist.stage.mozaws.net/v1/articles?_limit=20&_token=eyJsYXN0X21vZGlmaWVkIjoxNDI3OTM2NTI2MjA3fQ%3D%3D 	Average Request Time: 0.815953

Stats by URLs (10 slowests):
- https://readinglist.stage.mozaws.net/v1/articles?_limit=20&_token=eyJsYXN0X21vZGlmaWVkIjoxNDI3OTM2NTI2MjA3fQ%3D%3D	Average request time: 0.815953	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/articles/19442823-9093-426d-862c-59d71c6dac2a                         	Average request time: 0.440853	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/articles?_since=1427936511858                                         	Average request time: 0.437154	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/articles?_since=1427936513108&deleted=true                            	Average request time: 0.424371	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/articles/78ec4622-9a33-4e79-a2e5-3bb9eb72ee1e                         	Average request time: 0.39276	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/articles/08efcb7b-2b8d-417d-90c3-cccee0ea7526                         	Average request time: 0.313345	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/batch                                                                 	Average request time: 0.307419683544	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net/v1/articles?_limit=20&_token=eyJsYXN0X21vZGlmaWVkIjoxNDI3OTM2NTU1OTE2fQ%3D%3D	Average request time: 0.306262	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net:443/v1/articles/b8565585-078f-4559-9a2a-ee4a072b0745                         	Average request time: 0.272097	Hits success rate: 1.0
- https://readinglist.stage.mozaws.net/v1/articles?_limit=20&_token=eyJsYXN0X21vZGlmaWVkIjoxNDI3OTM2NTEyMTE3fQ%3D%3D	Average request time: 0.25361	Hits success rate: 1.0

make: *** [test] Error 1
```

