### PR TITLE
 Rework previous fix about empty titles

### DIFF
--- a/readinglist/tests/test_article_schema.py
+++ b/readinglist/tests/test_article_schema.py
@@ -34,7 +34,6 @@ class ArticleSchemaTest(unittest.TestCase):
     def test_record_validation_computed_values(self):
         self.assertIsNotNone(self.deserialized.get('stored_on'))
         self.assertIsNotNone(self.deserialized.get('added_on'))
-        self.assertIsNotNone(self.deserialized.get('last_modified'))
 
     def test_url_is_required(self):
         self.record.pop('url')

--- a/readinglist/tests/test_article_schema.py
+++ b/readinglist/tests/test_article_schema.py
@@ -64,10 +64,11 @@ class ArticleSchemaTest(unittest.TestCase):
                           self.schema.deserialize,
                           self.record)
 
-    def test_title_is_not_required(self):
+    def test_title_is_required(self):
         self.record.pop('title')
-        deserialized = self.schema.deserialize(self.record)
-        self.assertEqual(deserialized['title'], None)
+        self.assertRaises(colander.Invalid,
+                          self.schema.deserialize,
+                          self.record)
 
     def test_title_is_stripped(self):
         self.record['title'] = '  Nous Sommes Charlie  '
@@ -83,15 +84,20 @@ class ArticleSchemaTest(unittest.TestCase):
         deserialized = self.schema.deserialize(self.record)
         self.assertEqual(len(deserialized['title']), 1024)
 
-    def test_title_is_set_to_null_if_empty_string(self):
+    def test_title_allows_empty_string(self):
         self.record['title'] = ''
+        deserialized = self.schema.deserialize(self.record)
+        self.assertEqual(deserialized['title'], '')
+
+    def test_title_allows_null(self):
+        self.record['title'] = None
         deserialized = self.schema.deserialize(self.record)
         self.assertEqual(deserialized['title'], None)
 
-    def test_title_is_set_to_null_if_blank_string(self):
+    def test_title_is_set_to_empty_if_blank_string(self):
         self.record['title'] = '   '
         deserialized = self.schema.deserialize(self.record)
-        self.assertEqual(deserialized['title'], None)
+        self.assertEqual(deserialized['title'], '')
 
     def test_resolved_title_has_max_length(self):
         self.record['resolved_title'] = u'\u76d8' * 1025
@@ -103,15 +109,20 @@ class ArticleSchemaTest(unittest.TestCase):
         deserialized = self.schema.deserialize(self.record)
         self.assertEqual(deserialized['resolved_title'], 'Nous Sommes Charlie')
 
-    def test_resolved_title_is_set_to_null_if_empty_string(self):
+    def test_resolved_title_allows_empty_string(self):
         self.record['resolved_title'] = ''
+        deserialized = self.schema.deserialize(self.record)
+        self.assertEqual(deserialized['resolved_title'], '')
+
+    def test_resolved_title_allows_null(self):
+        self.record['resolved_title'] = None
         deserialized = self.schema.deserialize(self.record)
         self.assertEqual(deserialized['resolved_title'], None)
 
-    def test_resolved_title_is_set_to_null_if_blank_string(self):
+    def test_resolved_title_is_set_to_empty_if_blank_string(self):
         self.record['resolved_title'] = '   '
         deserialized = self.schema.deserialize(self.record)
-        self.assertEqual(deserialized['resolved_title'], None)
+        self.assertEqual(deserialized['resolved_title'], '')
 
     def test_added_by_is_required(self):
         self.record.pop('added_by')


### PR DESCRIPTION
I read again every comment in https://bugzilla.mozilla.org/show_bug.cgi?id=1152915 and had some doubts about the way we fixed the problem.

With the previous fix in #250 
* title field was not required anymore
* empty strings were stored as null

With this fix:
* title is required
* title is stored as null if provided as null
* title is stored as empty string if provided empty

@Natim r?