### PR TITLE
Upgrade to Cliquet 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: 2.7
 sudo: false
 services: redis-server
 addons:
-    postgresql: "9.3"
+    postgresql: "9.4"
 env:
     - TOX_ENV=py27
     - TOX_ENV=py34

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Upgraded to Cliquet 2.3+.
 
 **Breaking changes**
 
+- Now requires PostgreSQL 9.4+
 - Endpoints now expect articles to be posted in a ``data`` attribute
 - Endpoints responses now contain a ``data`` attribute
 - Endpoints switched from ``If-Modified-Since`` and ``If-Unmodified-Since``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,14 @@ This document describes changes between each past release.
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Upgraded to Cliquet 2.3+.
+
+**Breaking changes**
+
+- Endpoints now expect articles to be posted in a ``data`` attribute
+- Endpoints responses now contain a ``data`` attribute
+- Endpoints switched from ``If-Modified-Since`` and ``If-Unmodified-Since``
+  to Etags
 
 
 1.7.0 (2015-04-15)

--- a/config/readinglist.ini
+++ b/config/readinglist.ini
@@ -7,6 +7,8 @@ cliquet.cache_backend = cliquet.cache.postgresql
 cliquet.cache_url = postgres://postgres:postgres@localhost/postgres
 cliquet.storage_backend = cliquet.storage.postgresql
 cliquet.storage_url = postgres://postgres:postgres@localhost/postgres
+cliquet.permission_backend = cliquet.permission.postgresql
+cliquet.permission_url = postgres://postgres:postgres@localhost/postgres
 cliquet.http_scheme = http
 cliquet.retry_after_seconds = 30
 cliquet.eos =
@@ -14,7 +16,6 @@ cliquet.eos =
 # cliquet.logging_renderer = cliquet.logs.MozillaHekaRenderer
 
 pyramid.debug_notfound = true
-cliquet.basic_auth_enabled = true
 # cliquet.backoff = 10
 cliquet.userid_hmac_secret = b4c96a8692291d88fe5a97dd91846eb4
 cliquet.batch_max_requests = 25

--- a/loadtests/loadtest/__init__.py
+++ b/loadtests/loadtest/__init__.py
@@ -100,7 +100,7 @@ class TestBasic(TestCase):
             nb_initial_records -= 1
 
         resp = self.session.get(self.api_url('articles'), auth=self.auth)
-        records = resp.json()['items']
+        records = resp.json()['data']
 
         # Pick a random record
         self.random_record = random.choice(records)
@@ -133,9 +133,9 @@ class TestBasic(TestCase):
         else:
             self.test_all()
 
-    def _run_batch(self, data):
+    def _run_batch(self, body):
         resp = self.session.post(self.api_url('batch'),
-                                 data=json.dumps(data),
+                                 data=json.dumps(body),
                                  auth=self.auth,
                                  headers={'Content-Type': 'application/json'})
         self.incr_counter(resp.status_code)
@@ -147,8 +147,9 @@ class TestBasic(TestCase):
         data = build_article()
         resp = self.session.post(
             self.api_url('articles'),
-            data,
-            auth=self.auth)
+            data=json.dumps({'data': data}),
+            auth=self.auth,
+            headers={'Content-Type': 'application/json'})
         self.incr_counter(resp.status_code)
         self.assertEqual(resp.status_code, 201)
 
@@ -160,7 +161,7 @@ class TestBasic(TestCase):
             }
         }
         for i in range(25):
-            request = {"body": build_article()}
+            request = {"body": {'data': build_article()}}
             data.setdefault("requests", []).append(request)
 
         self._run_batch(data)
@@ -170,8 +171,9 @@ class TestBasic(TestCase):
         data.pop('id')
         resp = self.session.post(
             self.api_url('articles'),
-            data,
-            auth=self.auth)
+            data=json.dumps({'data': data}),
+            auth=self.auth,
+            headers={'Content-Type': 'application/json'})
         self.incr_counter(resp.status_code)
         self.assertEqual(resp.status_code, 200)
 
@@ -191,8 +193,8 @@ class TestBasic(TestCase):
         self.assertEqual(resp.status_code, 200)
 
     def _patch(self, url, data, status=200):
-        data = json.dumps(data)
-        resp = self.session.patch(url, data, auth=self.auth)
+        body = json.dumps({'data': data})
+        resp = self.session.patch(url, body, auth=self.auth)
         self.incr_counter(resp.status_code)
         self.assertEqual(resp.status_code, status)
 
@@ -215,7 +217,7 @@ class TestBasic(TestCase):
         # Get some random articles on which the batch will be applied
         url = self.api_url('articles?_limit=5&_sort=title')
         resp = self.session.get(url, auth=self.auth)
-        articles = resp.json()['items']
+        articles = resp.json()['data']
         urls = ['/articles/{}'.format(a['id']) for a in articles]
 
         data = {
@@ -277,7 +279,7 @@ class TestBasic(TestCase):
         # Get some random articles on which the batch will be applied
         url = self.api_url('articles?_limit=5&_sort=title')
         resp = self.session.get(url, auth=self.auth)
-        articles = resp.json()['items']
+        articles = resp.json()['data']
         urls = ['/articles/{}'.format(a['id']) for a in articles]
 
         data = {

--- a/readinglist/__init__.py
+++ b/readinglist/__init__.py
@@ -6,6 +6,7 @@ from pyramid.settings import asbool
 
 import cliquet
 
+
 # Module version, as defined in PEP-0396.
 __version__ = pkg_resources.get_distribution(__package__).version
 
@@ -14,6 +15,11 @@ API_VERSION = 'v%s' % __version__.split('.')[0]
 
 # Main readinglist logger
 logger = logging.getLogger(__name__)
+
+
+DEFAULT_SETTINGS = {
+    'cliquet.paginate_by': 100
+}
 
 
 def patch_gevent(settings):
@@ -31,12 +37,8 @@ def main(global_config, **settings):
 
     patch_gevent(settings)
 
-    cliquet.initialize(config, version=__version__)
-
-    # Force default pagination (if empty, None or 0)
-    paginate_by = config.registry.settings.get('cliquet.paginate_by')
-    if not paginate_by:
-        config.registry.settings['cliquet.paginate_by'] = 100
+    cliquet.initialize(config, version=__version__,
+                       default_settings=DEFAULT_SETTINGS)
 
     config.scan("readinglist.views")
     app = config.make_wsgi_app()

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -5,40 +5,19 @@ except ImportError:
 
 import webtest
 
-from cliquet.tests.support import FakeAuthentMixin
+from cliquet.tests.support import (BaseWebTest as CliquetBaseTest,
+                                   get_request_class)
 from readinglist import API_VERSION
 
 
-def get_request_class(prefix):
-
-    class PrefixedRequestClass(webtest.app.TestRequest):
-
-        @classmethod
-        def blank(cls, path, *args, **kwargs):
-            path = '/%s%s' % (prefix, path)
-            return webtest.app.TestRequest.blank(path, *args, **kwargs)
-
-    return PrefixedRequestClass
-
-
-class BaseWebTest(FakeAuthentMixin):
+class BaseWebTest(CliquetBaseTest):
     """Base Web Test to test your cornice service.
 
     It setups the database before each test and delete it after.
     """
 
-    app = webtest.TestApp("config:config/readinglist.ini",
-                          relative_to='.')
-
-    def __init__(self, *args, **kwargs):
-        super(BaseWebTest, self).__init__(*args, **kwargs)
-        self.app.RequestClass = get_request_class(prefix=API_VERSION)
-        self.db = self.app.app.registry.storage
-        self.db.initialize_schema()
-        self.headers.update({
-            'Content-Type': 'application/json',
-        })
-
-    def tearDown(self):
-        super(BaseWebTest, self).tearDown()
-        self.db.flush()
+    def _get_test_app(self, settings=None):
+        app = webtest.TestApp("config:config/readinglist.ini",
+                              relative_to='.')
+        app.RequestClass = get_request_class(API_VERSION)
+        return app

--- a/readinglist/tests/support.py
+++ b/readinglist/tests/support.py
@@ -15,6 +15,9 @@ class BaseWebTest(CliquetBaseTest):
 
     It setups the database before each test and delete it after.
     """
+    def __init__(self, *args, **kwargs):
+        super(BaseWebTest, self).__init__(*args, **kwargs)
+        self.storage.initialize_schema()
 
     def _get_test_app(self, settings=None):
         app = webtest.TestApp("config:config/readinglist.ini",

--- a/readinglist/tests/test_views_article.py
+++ b/readinglist/tests/test_views_article.py
@@ -26,35 +26,35 @@ class IntegrationTest(BaseWebTest, unittest.TestCase):
             data = MINIMALIST_ARTICLE.copy()
             data['url'] += '-%s' % i
             self.app.post_json('/articles',
-                               data,
+                               {'data': data},
                                headers=self.headers)
         resp = self.app.get('/articles', headers=self.headers)
-        self.assertEqual(len(resp.json['items']), 100)
+        self.assertEqual(len(resp.json['data']), 100)
 
 
 class ArticleCreationTest(BaseWebTest, unittest.TestCase):
     def test_stored_on_is_forced_even_if_specified(self):
-        body = MINIMALIST_ARTICLE.copy()
+        data = MINIMALIST_ARTICLE.copy()
         for value in ('', 123, None):
-            body['stored_on'] = value
+            data['stored_on'] = value
             resp = self.app.post_json('/articles',
-                                      body,
+                                      {'data': data},
                                       headers=self.headers)
-            self.assertNotEqual(resp.json['stored_on'], value)
+            self.assertNotEqual(resp.json['data']['stored_on'], value)
 
 
 class ArticleModificationTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super(ArticleModificationTest, self).setUp()
         resp = self.app.post_json('/articles',
-                                  MINIMALIST_ARTICLE,
+                                  {'data': MINIMALIST_ARTICLE},
                                   headers=self.headers)
-        self.before = resp.json
+        self.before = resp.json['data']
         self.url = '/articles/{id}'.format(id=self.before['id'])
 
     def test_replacing_records_is_not_allowed(self):
         resp = self.app.put_json(self.url,
-                                 MINIMALIST_ARTICLE,
+                                 {'data': MINIMALIST_ARTICLE},
                                  headers=self.headers,
                                  status=405)
         self.assertEqual(resp.json['errno'], 115)
@@ -64,41 +64,43 @@ class ArticleModificationTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(self.before['resolved_title'], "MoFo")
 
     def test_resolved_url_and_titles_can_be_modified(self):
-        body = {
+        data = {
             'resolved_url': 'https://ssl.mozilla.org',
             'resolved_title': 'MoFo secure'
         }
-        updated = self.app.patch_json(self.url, body, headers=self.headers)
+        updated = self.app.patch_json(self.url, {'data': data},
+                                      headers=self.headers)
         self.assertNotEqual(self.before['resolved_url'],
-                            updated.json['resolved_url'])
+                            updated.json['data']['resolved_url'])
         self.assertNotEqual(self.before['resolved_title'],
-                            updated.json['resolved_title'])
+                            updated.json['data']['resolved_title'])
 
     def test_cannot_modify_url(self):
-        body = {'url': 'http://immutable.org'}
+        data = {'url': 'http://immutable.org'}
         self.app.patch_json(self.url,
-                            body,
+                            {'data': data},
                             headers=self.headers,
                             status=400)
 
     def test_cannot_modify_stored_on(self):
-        body = {'stored_on': 1234}
+        data = {'stored_on': 1234}
         self.app.patch_json(self.url,
-                            body,
+                            {'data': data},
                             headers=self.headers,
                             status=400)
 
     def test_stored_on_is_preserved_after_modification(self):
-        body = {'stored_on': self.before['stored_on']}
+        data = {'stored_on': self.before['stored_on']}
         resp = self.app.patch_json(self.url,
-                                   body,
+                                   {'data': data},
                                    headers=self.headers)
-        self.assertEqual(resp.json['stored_on'], self.before['stored_on'])
+        self.assertEqual(resp.json['data']['stored_on'],
+                         self.before['stored_on'])
 
     def test_cannot_mark_as_read_without_by_and_on(self):
-        body = {'unread': False}
+        data = {'unread': False}
         resp = self.app.patch_json(self.url,
-                                   body,
+                                   {'data': data},
                                    headers=self.headers,
                                    status=400)
         self.assertIn('Missing marked_read_by', resp.json['message'])
@@ -109,9 +111,9 @@ class ReadArticleModificationTest(BaseWebTest, unittest.TestCase):
         super(ReadArticleModificationTest, self).setUp()
 
         resp = self.app.post_json('/articles',
-                                  MINIMALIST_ARTICLE,
+                                  {'data': MINIMALIST_ARTICLE},
                                   headers=self.headers)
-        before = resp.json
+        before = resp.json['data']
         self.url = '/articles/{id}'.format(id=before['id'])
 
         mark_read = {
@@ -119,12 +121,13 @@ class ReadArticleModificationTest(BaseWebTest, unittest.TestCase):
             'unread': False,
             'marked_read_by': 'FxOS',
             'marked_read_on': 1234}
-        resp = self.app.patch_json(self.url, mark_read, headers=self.headers)
-        self.record = resp.json
+        resp = self.app.patch_json(self.url, {'data': mark_read},
+                                   headers=self.headers)
+        self.record = resp.json['data']
 
     def refetch(self):
         resp = self.app.get(self.url, headers=self.headers)
-        return resp.json
+        return resp.json['data']
 
     def test_patch_changes_are_taken_into_account(self):
         record = self.refetch()
@@ -134,7 +137,7 @@ class ReadArticleModificationTest(BaseWebTest, unittest.TestCase):
 
     def test_mark_by_and_on_are_set_to_none_if_unread_is_true(self):
         self.app.patch_json(self.url,
-                            {'unread': True},
+                            {'data': {'unread': True}},
                             headers=self.headers)
         record = self.refetch()
         self.assertIsNone(record['marked_read_by'])
@@ -142,7 +145,7 @@ class ReadArticleModificationTest(BaseWebTest, unittest.TestCase):
 
     def test_read_position_is_reset_when_unread_is_set_to_true(self):
         self.app.patch_json(self.url,
-                            {'unread': True},
+                            {'data': {'unread': True}},
                             headers=self.headers)
         record = self.refetch()
         self.assertEqual(record['read_position'], 0)
@@ -150,97 +153,66 @@ class ReadArticleModificationTest(BaseWebTest, unittest.TestCase):
     def test_read_position_is_reset_only_if_was_read(self):
         # https://github.com/mozilla-services/readinglist/issues/213
         self.app.patch_json(self.url,
-                            {'unread': True},
+                            {'data': {'unread': True}},
                             headers=self.headers)
-        body = {'unread': True, 'read_position': 119}
+        data = {'unread': True, 'read_position': 119}
         resp = self.app.patch_json(self.url,
-                                   body,
+                                   {'data': data},
                                    headers=self.headers)
-        self.assertEqual(resp.json['read_position'], 119)
+        self.assertEqual(resp.json['data']['read_position'], 119)
 
     def test_read_position_is_ignored_if_set_to_lower_value(self):
         self.app.patch_json(self.url,
-                            {'read_position': 41},
+                            {'data': {'read_position': 41}},
                             headers=self.headers)
         record = self.refetch()
         self.assertEqual(record['read_position'], 42)
 
     def test_read_position_is_saved_if_set_to_higher_value(self):
         self.app.patch_json(self.url,
-                            {'read_position': 43},
+                            {'data': {'read_position': 43}},
                             headers=self.headers)
         record = self.refetch()
         self.assertEqual(record['read_position'], 43)
 
     def test_marked_by_and_on_are_ignored_if_already_unread(self):
-        body = {
+        data = {
             'unread': False,
             'marked_read_by': 'Android',
             'marked_read_on': 543210}
         resp = self.app.patch_json(self.url,
-                                   body,
+                                   {'data': data},
                                    headers=self.headers)
-        self.assertNotEqual(resp.json['marked_read_by'], 'Android')
-        self.assertNotEqual(resp.json['marked_read_on'], 543210)
+        self.assertNotEqual(resp.json['data']['marked_read_by'], 'Android')
+        self.assertNotEqual(resp.json['data']['marked_read_on'], 543210)
 
     def test_timestamp_is_not_updated_if_already_unread(self):
-        body = {
+        data = {
             'unread': False,
             'marked_read_by': 'Android',
             'marked_read_on': 543210}
         resp = self.app.patch_json(self.url,
-                                   body,
+                                   {'data': data},
                                    headers=self.headers)
-        self.assertEqual(resp.json['last_modified'],
+        self.assertEqual(resp.json['data']['last_modified'],
                          self.record['last_modified'])
-
-    def test_body_behavior_is_set_to_full_by_default(self):
-        body = {'unread': "True", 'read_position': 10}
-        resp = self.app.patch_json(self.url,
-                                   body,
-                                   headers=self.headers)
-        self.assertEqual(set(resp.json.keys()), {
-            'added_by', 'added_on', 'archived', 'excerpt', 'favorite', 'id',
-            'is_article', 'last_modified', 'marked_read_by', 'marked_read_on',
-            'preview', 'read_position', 'resolved_title', 'resolved_url',
-            'stored_on', 'title', 'unread', 'url', 'word_count'})
-
-    def test_body_behavior_set_to_diff_return_only_diff(self):
-        body = {'unread': "True", 'read_position': 10}
-        self.headers.update({
-            'Response-Behavior': 'diff'
-        })
-        resp = self.app.patch_json(self.url,
-                                   body,
-                                   headers=self.headers)
-        self.assertDictEqual(resp.json, {'read_position': 0})
-
-    def test_body_behavior_set_to_light_return_only_changes(self):
-        body = {'unread': "True", 'read_position': 10}
-        self.headers.update({
-            'Response-Behavior': 'light'
-        })
-        resp = self.app.patch_json(self.url,
-                                   body,
-                                   headers=self.headers)
-        self.assertDictEqual(resp.json, {'unread': True, 'read_position': 0})
 
 
 class ConflictingArticleTest(BaseWebTest, unittest.TestCase):
     def setUp(self):
         super(ConflictingArticleTest, self).setUp()
         resp = self.app.post_json('/articles',
-                                  MINIMALIST_ARTICLE,
+                                  {'data': MINIMALIST_ARTICLE},
                                   headers=self.headers)
-        self.before = resp.json
+        self.before = resp.json['data']
         self.url = '/articles/{id}'.format(id=self.before['id'])
 
     def test_creating_with_a_conflicting_url_returns_existing(self):
         resp = self.app.post_json('/articles',
-                                  MINIMALIST_ARTICLE,
+                                  {'data': MINIMALIST_ARTICLE},
                                   headers=self.headers)
         self.assertEqual(resp.status_code, 200)
-        self.assertDictEqual(self.before, resp.json)
+        self.assertDictEqual(self.before, resp.json['data'])
 
     def test_creating_with_a_conflicting_resolved_url_returns_existing(self):
         # Just double-check that resolved url was set from url
@@ -252,22 +224,22 @@ class ConflictingArticleTest(BaseWebTest, unittest.TestCase):
         record['url'] = 'http://bit.ly/abc'
 
         resp = self.app.post_json('/articles',
-                                  record,
+                                  {'data': record},
                                   headers=self.headers)
         self.assertEqual(resp.status_code, 200)
-        self.assertDictEqual(self.before, resp.json)
+        self.assertDictEqual(self.before, resp.json['data'])
 
     def test_return_409_on_conflict_with_resolved_url(self):
         record = MINIMALIST_ARTICLE.copy()
         record['url'] = 'https://ssl.mozilla.org'
         resp = self.app.post_json('/articles',
-                                  record,
+                                  {'data': record},
                                   headers=self.headers)
-        url = '/articles/{id}'.format(id=resp.json['id'])
+        url = '/articles/{id}'.format(id=resp.json['data']['id'])
 
         patch = {'resolved_url': MINIMALIST_ARTICLE['url']}
         self.app.patch_json(url,
-                            patch,
+                            {'data': patch},
                             headers=self.headers,
                             status=409)
 
@@ -277,56 +249,56 @@ class DeletedArticleTest(BaseWebTest, unittest.TestCase):
         super(DeletedArticleTest, self).setUp()
 
         resp = self.app.post_json('/articles',
-                                  MINIMALIST_ARTICLE,
+                                  {'data': MINIMALIST_ARTICLE},
                                   headers=self.headers)
-        self.before = resp.json
+        self.before = resp.json['data']
         self.url = '/articles/{id}'.format(id=self.before['id'])
         self.last_modified = self.before['last_modified']
         self.deleted = self.app.delete(self.url, headers=self.headers)
 
     def test_delete_article_returns_status_deleted(self):
-        self.assertEqual(self.deleted.json['deleted'], True)
+        self.assertEqual(self.deleted.json['data']['deleted'], True)
 
     def test_deleted_articles_are_marked_with_status_deleted(self):
         resp = self.app.get('/articles?_since=%s' % self.last_modified,
                             headers=self.headers)
-        self.assertEqual(resp.json['items'][0]['deleted'], True)
+        self.assertEqual(resp.json['data'][0]['deleted'], True)
 
     def test_deleted_articles_are_stripped(self):
         resp = self.app.get('/articles?_since=%s' % self.last_modified,
                             headers=self.headers)
-        self.assertEqual(sorted(resp.json['items'][0].keys()),
+        self.assertEqual(sorted(resp.json['data'][0].keys()),
                          ['deleted', 'id', 'last_modified'])
 
     def test_url_unicity_does_not_interfere_with_deleted_records(self):
         self.app.post_json('/articles',
-                           MINIMALIST_ARTICLE,
+                           {'data': MINIMALIST_ARTICLE},
                            headers=self.headers)
 
     def test_deleted_articles_can_be_filtered(self):
         self.app.post_json('/articles',
-                           MINIMALIST_ARTICLE,
+                           {'data': MINIMALIST_ARTICLE},
                            headers=self.headers)
         only_deleted = '/articles?_since=%s&deleted=true' % self.last_modified
         resp = self.app.get(only_deleted,
                             headers=self.headers)
-        results = resp.json['items']
+        results = resp.json['data']
         self.assertEqual(len(results), 1)
         self.assertTrue(results[0]['deleted'])
 
     def test_deleted_articles_can_be_sorted_on_deleted_status(self):
         # Create with default status
         self.app.post_json('/articles',
-                           MINIMALIST_ARTICLE,
+                           {'data': MINIMALIST_ARTICLE},
                            headers=self.headers)
 
         # Create another and archive
-        body = MINIMALIST_ARTICLE.copy()
-        body['url'] = 'http://host.com'
+        data = MINIMALIST_ARTICLE.copy()
+        data['url'] = 'http://host.com'
         resp = self.app.post_json('/articles',
-                                  body,
+                                  {'data': data},
                                   headers=self.headers)
-        self.app.patch_json('/articles/%s' % resp.json['id'],
+        self.app.patch_json('/articles/%s' % resp.json['data']['id'],
                             {'archived': True},
                             headers=self.headers)
 
@@ -334,6 +306,6 @@ class DeletedArticleTest(BaseWebTest, unittest.TestCase):
         sort_deleted = '/articles?_since=%s&_sort=deleted' % self.last_modified
         resp = self.app.get(sort_deleted,
                             headers=self.headers)
-        records = resp.json['items']
+        records = resp.json['data']
         self.assertEqual(records[0]['deleted'], True)
         self.assertNotIn('deleted', records[1])

--- a/readinglist/tests/test_views_hello.py
+++ b/readinglist/tests/test_views_hello.py
@@ -1,7 +1,4 @@
-import mock
-from webtest.app import TestRequest
-
-from readinglist import __version__ as VERSION, API_VERSION
+from readinglist import __version__ as VERSION
 
 from .support import BaseWebTest, unittest
 
@@ -15,36 +12,3 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(response.json['hello'], 'readinglist')
         self.assertEqual(response.json['documentation'],
                          'https://readinglist.readthedocs.org/')
-
-    def test_do_not_returns_eos_if_empty_in_settings(self):
-        response = self.app.get('/')
-        self.assertNotIn('eos', response.json)
-
-    def test_returns_eos_if_not_empty_in_settings(self):
-        eos = '2069-02-21'
-        with mock.patch.dict(
-                self.app.app.registry.settings,
-                [('cliquet.eos', eos)]):
-            response = self.app.get('/')
-            self.assertEqual(response.json['eos'], eos)
-
-    def test_redirect_to_version(self):
-        # We don't want the prefix to be automatically added for this test.
-        original_request_class = self.app.RequestClass
-
-        try:
-            self.app.RequestClass = TestRequest  # Standard RequestClass.
-
-            # GET on the hello view.
-            response = self.app.get('/')
-            self.assertEqual(response.status_int, 307)
-            self.assertEqual(response.location,
-                             'http://localhost/%s/' % API_VERSION)
-
-            # GET on the fields view.
-            response = self.app.get('/articles')
-            self.assertEqual(response.status_int, 307)
-            self.assertEqual(response.location,
-                             'http://localhost/%s/articles' % API_VERSION)
-        finally:
-            self.app.RequestClass = original_request_class

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ REQUIREMENTS = [
     'cornice>=0.20.0',
     'six>=1.9.0',
     'waitress>=0.8.9',
-    'cliquet[postgresql,monitoring]>=1.7.0',
+    'cliquet[postgresql,monitoring]>=2.1.0',
 ]
 
 ENTRY_POINTS = {

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,6 @@ with open(os.path.join(here, 'CHANGELOG.rst')) as f:
 
 
 REQUIREMENTS = [
-    'colander>=1.0',
-    'cornice>=0.20.0',
-    'six>=1.9.0',
     'waitress>=0.8.9',
     'cliquet[postgresql,monitoring]>=2.1.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(here, 'CHANGELOG.rst')) as f:
 
 REQUIREMENTS = [
     'waitress>=0.8.9',
-    'cliquet[postgresql,monitoring]>=2.1.0',
+    'cliquet[postgresql,monitoring]>=2.3',
 ]
 
 ENTRY_POINTS = {


### PR DESCRIPTION
I wanted to compare load tests performances now that *Cliquet* has Pypy support. So I started to port *Reading List*.

→ Good exercise, I found [a bug](https://github.com/mozilla-services/cliquet/issues/348) in Cliquet :)

* [x] Upgrade deps
* [x] Update tests payloads and responses
* [x] Clean-up code now available in Cliquet
* [x] Find an elegant fix for https://github.com/mozilla-services/cliquet/issues/348
* [x] Fix tests