### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -188,7 +188,7 @@ changes on schema have to be applied manually:
   (*Default: 50*) (mozilla-services/cliquet#112)
 - Add `StatsD <https://github.com/etsy/statsd/>`_ support,
   enabled with ``cliquet.statsd_url = udp://server:port`` (mozilla-services/cliquet#114)
-- Add `Sentry <http://sentry.readthedocs.org>`_ support,
+- Add `Sentry <https://sentry.readthedocs.io>`_ support,
   enabled with ``cliquet.sentry_url = http://user:pass@server/1`` (mozilla-services/cliquet#110)
 
 **Bug fixes**
@@ -310,7 +310,7 @@ changes on schema have to be applied manually:
 - Conditional changes for some articles attributes (ref #6)
 - Batching support (ref #2)
 - Pagination support (ref #25)
-- Online documentation available at http://readinglist.readthedocs.org (ref PR #73)
+- Online documentation available at https://readinglist.readthedocs.io (ref PR #73)
 - Basic Auth nows support any user/password combination (ref PR #78)
 
 **Bug fixes**

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Reading List
     :target: https://travis-ci.org/mozilla-services/readinglist
 
 .. |readthedocs| image:: https://readthedocs.org/projects/readinglist/badge/?version=latest
-    :target: http://readinglist.readthedocs.org/en/latest/
+    :target: https://readinglist.readthedocs.io/en/latest/
     :alt: Documentation Status
 
 .. |master-coverage| image::
@@ -18,6 +18,6 @@ Reading List
 *Reading List* is a service that aims to synchronize a list of articles URLs
 between a set of devices owned by a same account.
 
-* `Online documentation <http://readinglist.readthedocs.org/en/latest/>`_
+* `Online documentation <https://readinglist.readthedocs.io/en/latest/>`_
 * `Issue tracker <https://github.com/mozilla-services/readinglist/issues>`_
-* `Contributing <http://readinglist.readthedocs.org/en/latest/contributing.html>`_
+* `Contributing <https://readinglist.readthedocs.io/en/latest/contributing.html>`_

--- a/config/readinglist.ini
+++ b/config/readinglist.ini
@@ -2,7 +2,7 @@
 use = egg:readinglist
 
 cliquet.project_name = readinglist
-cliquet.project_docs = https://readinglist.readthedocs.org/
+cliquet.project_docs = https://readinglist.readthedocs.io/
 cliquet.cache_backend = cliquet.cache.postgresql
 cliquet.cache_url = postgres://postgres:postgres@localhost/postgres
 cliquet.storage_backend = cliquet.storage.postgresql

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 Run locally
 ===========
 
-*Reading List* is based on top of the `cliquet <https://cliquet.rtfd.org>`_ project, and
+*Reading List* is based on top of the `cliquet <https://cliquet.readthedocs.io>`_ project, and
 as such, please refer to cliquet's documentation for more details.
 
 
@@ -41,7 +41,7 @@ Authentication
 By default, *Reading List* relies on Firefox Account OAuth2 Bearer tokens to authenticate
 users.
 
-See `cliquet documentation <http://cliquet.readthedocs.org/en/latest/configuration.html#authentication>`_
+See `cliquet documentation <https://cliquet.readthedocs.io/en/latest/configuration.html#authentication>`_
 to configure authentication options.
 
 

--- a/loadtests/server.ini
+++ b/loadtests/server.ini
@@ -2,7 +2,7 @@
 use = egg:readinglist
 
 cliquet.project_name = readinglist
-cliquet.project_docs = https://readinglist.rtfd.org/
+cliquet.project_docs = https://readinglist.readthedocs.io/
 cliquet.http_scheme = http
 cliquet.basic_auth_enabled = true
 cliquet.cache_backend = cliquet.cache.postgresql

--- a/readinglist/tests/test_views_hello.py
+++ b/readinglist/tests/test_views_hello.py
@@ -11,4 +11,4 @@ class HelloViewTest(BaseWebTest, unittest.TestCase):
         self.assertEqual(response.json['url'], 'http://localhost/v2/')
         self.assertEqual(response.json['hello'], 'readinglist')
         self.assertEqual(response.json['documentation'],
-                         'https://readinglist.readthedocs.org/')
+                         'https://readinglist.readthedocs.io/')


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.